### PR TITLE
MVV-LVA, Killer moves and history moves implementation

### DIFF
--- a/chess_board/chess_move.hpp
+++ b/chess_board/chess_move.hpp
@@ -81,6 +81,27 @@ public:
         return move_data > other_move.move_data;
     }
 
+    [[nodiscard]] bool is_quiet() const {
+        switch (get_move_type()) {
+            case QUIET:
+            case DOUBLE_PAWN_PUSH:
+            case KING_CASTLE:
+            case QUEEN_CASTLE:
+                return true;
+            case CAPTURE:
+            case EN_PASSANT:
+            case KNIGHT_PROMOTION:
+            case BISHOP_PROMOTION:
+            case ROOK_PROMOTION:
+            case QUEEN_PROMOTION:
+            case KNIGHT_PROMOTION_CAPTURE:
+            case BISHOP_PROMOTION_CAPTURE:
+            case ROOK_PROMOTION_CAPTURE:
+            case QUEEN_PROMOTION_CAPTURE:
+                return false;
+        }
+    }
+
     [[nodiscard]] std::string to_string() const {
         std::string move_string;
         move_string.append(square_to_string[get_from()]);

--- a/search/move_ordering/move_ordering.hpp
+++ b/search/move_ordering/move_ordering.hpp
@@ -2,11 +2,33 @@
 #define MOTOR_MOVE_ORDERING_HPP
 
 #include "../../move_generation/move_list.hpp"
+#include "../search_data.hpp"
 
-void score_moves(move_list & movelist, const chess_move & tt_move) {
+constexpr static int mvv_lva[7][6] = {
+//attacker:  P, N,  B,  R,  Q,  NONE
+        {6,  5, 4, 3, 2, 1},    // victim PAWN
+        {12, 11, 10, 9, 8, 7, },   // victim KNIGHT
+        {18, 17, 16, 15, 14, 13},    // victim BISHOP
+        {24, 23, 22, 21, 20, 19},    // victim ROOK
+        {31, 30, 29, 28, 27, 26},    // victim QUEEN
+        {0,  0,  0,  0,  0,  0},    // victim NONE
+        {25, 0, 0, 0, 0, 0}
+};
+
+void score_moves(board & chessboard, move_list & movelist, search_data & data, const chess_move & tt_move) {
     for (chess_move & move : movelist) {
+        const std::uint8_t from = move.get_from();
+        const std::uint8_t to   = move.get_to();
         if (move == tt_move) {
             move.set_score(16383);
+        } else if (!move.is_quiet()) {
+            move.set_score(15000 + mvv_lva[chessboard.get_piece(to)][chessboard.get_piece(from)]);
+        } else if (data.get_killer(0) == move){
+            move.set_score(14999);
+        } else if (data.get_killer(1) == move){
+            move.set_score(14998);
+        } else {
+            move.set_score(data.get_history(from, to));
         }
     }
 }

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -47,9 +47,10 @@ std::int16_t alpha_beta(board & chessboard, search_data & data, std::int16_t alp
     }
 
     if (depth <= 0) {
-        //return evaluate<color>(chessboard);
         return quiescence_search<color>(chessboard, data, alpha, beta);
     }
+
+    bool in_check = chessboard.in_check();
 
     Bound flag = Bound::UPPER;
 
@@ -65,7 +66,7 @@ std::int16_t alpha_beta(board & chessboard, search_data & data, std::int16_t alp
     generate_all_moves<color, false>(chessboard, movelist);
 
     if (movelist.size() == 0) {
-        if (chessboard.in_check()) {
+        if (in_check) {
             return data.mate_value();
         } else {
             return 0;
@@ -73,7 +74,7 @@ std::int16_t alpha_beta(board & chessboard, search_data & data, std::int16_t alp
     }
 
     std::int16_t best_score = -INF;
-    score_moves(movelist, best_move);
+    score_moves(chessboard, movelist, data, best_move);
 
     for (std::uint8_t moves_searched = 0; moves_searched < movelist.size(); moves_searched++) {
         const chess_move & chessmove = movelist.get_next_move(moves_searched);
@@ -105,6 +106,11 @@ std::int16_t alpha_beta(board & chessboard, search_data & data, std::int16_t alp
 
         if (alpha >= beta) {
             flag = Bound::LOWER;
+            if (chessmove.is_quiet()) {
+                data.update_killer(chessmove);
+
+                data.update_history(chessmove.get_from(), chessmove.get_to(), depth);
+            }
             break;
         }
     }

--- a/search/search_data.hpp
+++ b/search/search_data.hpp
@@ -48,6 +48,24 @@ public:
     void augment_ply() {
         ply++;
     }
+
+    void update_killer(chess_move move) {
+        killer_moves[ply][0] = killer_moves[ply][1];
+        killer_moves[ply][1] = move;
+    }
+
+    chess_move get_killer(int index) {
+        return killer_moves[ply][index];
+    }
+
+    void update_history(std::uint8_t from, std::uint8_t to, std::int8_t depth) {
+        history_moves[from][to] += depth * depth;
+    }
+
+    std::uint16_t get_history(std::uint8_t from, std::uint8_t to) {
+        return history_moves[from][to];
+    }
+
 private:
     std::int16_t ply;
 
@@ -56,6 +74,8 @@ private:
     time_keeper timekeeper;
 
     std::uint64_t nodes_searched;
+    chess_move killer_moves[MAX_DEPTH][2] = {};
+    std::uint16_t history_moves[64][64] = {};
 };
 
 #endif //MOTOR_SEARCH_DATA_HPP


### PR DESCRIPTION
TC=10+0.1
MVV-LVA
Score of dev vs old: 769 - 599 - 417  [0.548] 1785
...      dev playing White: 447 - 239 - 206  [0.617] 892
...      dev playing Black: 322 - 360 - 211  [0.479] 893
...      White vs Black: 807 - 561 - 417  [0.569] 1785
Elo difference: 33.2 +/- 14.1, LOS: 100.0 %, DrawRatio: 23.4 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match

Killers
Score of dev vs old: 628 - 465 - 371  [0.556] 1464
...      dev playing White: 356 - 201 - 175  [0.606] 732
...      dev playing Black: 272 - 264 - 196  [0.505] 732
...      White vs Black: 620 - 473 - 371  [0.550] 1464
Elo difference: 38.8 +/- 15.4, LOS: 100.0 %, DrawRatio: 25.3 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match

History
Score of dev vs old: 514 - 355 - 309  [0.567] 1178
...      dev playing White: 307 - 147 - 136  [0.636] 590
...      dev playing Black: 207 - 208 - 173  [0.499] 588
...      White vs Black: 515 - 354 - 309  [0.568] 1178
Elo difference: 47.2 +/- 17.1, LOS: 100.0 %, DrawRatio: 26.2 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match