### PR TITLE
Reverse futility pruning

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -61,8 +61,18 @@ std::int16_t alpha_beta(board & chessboard, search_data & data, std::int16_t alp
     const TT_entry & tt_entry = tt[zobrist_key];
     chess_move best_move;
 
+    bool tt_hit = false;
     if (tt_entry.zobrist == zobrist_key) {
         best_move = tt_entry.tt_move;
+        tt_hit = true;
+    }
+
+    if constexpr (!is_pv) {
+        std::int16_t eval = evaluate<color>(chessboard);
+        if (!in_check && !tt_hit && depth < 7 && eval - 100 * depth >= beta) {
+            // reverse futility pruning
+            return beta;
+        }
     }
 
     move_list movelist;


### PR DESCRIPTION
TC=10+0.1
Score of dev vs old: 302 - 155 - 186  [0.614] 643
...      dev playing White: 171 - 60 - 92  [0.672] 323
...      dev playing Black: 131 - 95 - 94  [0.556] 320
...      White vs Black: 266 - 191 - 186  [0.558] 643
Elo difference: 80.9 +/- 23.0, LOS: 100.0 %, DrawRatio: 28.9 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match