### PR TITLE
Internal iterative reduction

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -84,6 +84,11 @@ std::int16_t alpha_beta(board & chessboard, search_data & data, std::int16_t alp
                 }
             }
         }
+    } else if (depth >= 4) {
+        depth--;
+        if constexpr (is_pv) {
+            depth--;
+        }
     }
 
     std::int16_t eval = evaluate<color>(chessboard);


### PR DESCRIPTION
TC=10+0.1
Score of dev vs old: 1033 - 890 - 1383  [0.522] 3306
...      dev playing White: 665 - 264 - 724  [0.621] 1653
...      dev playing Black: 368 - 626 - 659  [0.422] 1653
...      White vs Black: 1291 - 632 - 1383  [0.600] 3306
Elo difference: 15.0 +/- 9.0, LOS: 99.9 %, DrawRatio: 41.8 %
SPRT: llr 2.95 (100.3%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match