### PR TITLE
razoring on non tt hits

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -106,7 +106,7 @@ std::int16_t alpha_beta(board & chessboard, search_data & data, std::int16_t alp
             }
 
             // razoring
-            if (depth <= 6 && eval + 150 * depth <= alpha) {
+            if (!tt_hit && depth <= 6 && eval + 150 * depth <= alpha) {
                 eval = quiescence_search<color>(chessboard, data, alpha, beta);
                 if(eval <= alpha) {
                     return eval;


### PR DESCRIPTION
Score of dev vs old: 623 - 488 - 764  [0.536] 1875
...      dev playing White: 417 - 152 - 369  [0.641] 938
...      dev playing Black: 206 - 336 - 395  [0.431] 937
...      White vs Black: 753 - 358 - 764  [0.605] 1875
Elo difference: 25.1 +/- 12.1, LOS: 100.0 %, DrawRatio: 40.7 %
SPRT: llr 2.96 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match