### PR TITLE
Bug fixes

### DIFF
--- a/chess_board/board.hpp
+++ b/chess_board/board.hpp
@@ -384,7 +384,7 @@ public:
 
         if constexpr (make) {
             hash_key.update_psqt_hash(our_color, piece, square);
-            hash_key.update_psqt_hash(our_color, captured_piece, square);
+            hash_key.update_psqt_hash(their_color, captured_piece, square);
         }
     }
     

--- a/cli/uci.hpp
+++ b/cli/uci.hpp
@@ -89,9 +89,9 @@ void uci_go(board& b, const std::string& command) {
         } else if (tokens[i] == "depth") {
             info.max_depth = std::stoi(tokens[i + 1]); 
         } else if (tokens[i] == "movetime") {
-            //info.movetime = std::stoi(tokens[i + 1]);  // NOT SUPPORTED RIGHT NOW
+            // info.movetime = std::stoi(tokens[i + 1]);  // NOT SUPPORTED RIGHT NOW
         } else if (tokens[i] == "infinite") {
-            //info.infinite = true;                      // NOT SUPPORTED RIGHT NOW
+            // info.infinite = true;                      
         }
     }
 
@@ -113,9 +113,9 @@ void uci_process(board& b, const std::string& line) {
     } else if (command == "isready") {
         std::cout << "readyok" << std::endl;
     } else if (command == "uci") {
-        std::cout << "id name Motor 0.1.0"<< std::endl;
-        std::cout << "id author Martin Novak" << std::endl;      
-        std::cout << "option name Hash type spin default " << 8 << " min 1 max 512\n";
+        std::cout << "id name Motor " << std::endl;
+        std::cout << "id author Martin Novak " << std::endl;      
+        std::cout << "option name Hash type spin default " << 8 << " min 1 max 1024" << std::endl;
         std::cout << "uciok" << std::endl;
     } else if (command == "ucinewgame") {
         history_table.clear();
@@ -129,7 +129,7 @@ void uci_process(board& b, const std::string& line) {
         }
 
         if (tokens.size() >= 4) {
-            if (tokens[1] == "hash") {
+            if (tokens[1] == "Hash" || tokens[1] == "hash") {
                 tt.resize(std::stoi(tokens[3]) * 1024 * 1024);
             }
         } else {
@@ -146,10 +146,14 @@ void uci_process(board& b, const std::string& line) {
 void uci_mainloop() {
     board chessboard;
     std::string line{};
+    std::ofstream outputFile("commands.txt");
 
     while (std::getline(std::cin, line)) {
+        outputFile << line << std::endl;
         uci_process(chessboard, line);
     }
+
+    outputFile.close();
 }
 
 #endif //MOTOR_UCI_HPP

--- a/cli/uci.hpp
+++ b/cli/uci.hpp
@@ -5,7 +5,6 @@
 #include <iomanip>
 #include <chrono>
 #include <cmath>
-#include <fstream>
 
 #include "../chess_board/board.hpp"
 #include "../move_generation/move_list.hpp"
@@ -48,7 +47,11 @@ void position_uci(board & b, const std::string & command) {
         b.fen_to_board(fen);
     }
 
-    if (moves_pos == std::string::npos) return;
+    if (moves_pos == std::string::npos) {
+        set_position(b);
+        return;
+    }
+
 
     std::stringstream move_ss(command.substr(moves_pos + 5));
     std::vector<std::string> moves;
@@ -146,14 +149,10 @@ void uci_process(board& b, const std::string& line) {
 void uci_mainloop() {
     board chessboard;
     std::string line{};
-    std::ofstream outputFile("commands.txt");
 
     while (std::getline(std::cin, line)) {
-        outputFile << line << std::endl;
         uci_process(chessboard, line);
     }
-
-    outputFile.close();
 }
 
 #endif //MOTOR_UCI_HPP

--- a/search/move_ordering/see.hpp
+++ b/search/move_ordering/see.hpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include "../../chess_board/board.hpp"
 
-constexpr std::int32_t SEE_VALUES[7] = {100, 300, 300, 450, 900, 30'000, 0};
+constexpr std::int32_t SEE_VALUES[7] = {100, 450, 450, 650, 1250, 30'000, 0};
 
 template <Color color>
 static bool see(board & chessboard, const chess_move & capture, int threshold = 0)  {
@@ -12,12 +12,9 @@ static bool see(board & chessboard, const chess_move & capture, int threshold = 
     Square to   = capture.get_to();
 
     Piece piece = chessboard.get_piece(from);
-    
-    /*
     if (piece == Pawn || piece == King) {
         return true;
     }
-    */
 
     int side_to_capture = color ^ 1;
 
@@ -35,7 +32,7 @@ static bool see(board & chessboard, const chess_move & capture, int threshold = 
     rooks   |= queens;
     bishops |= queens;
 
-    std::uint64_t occupancy = chessboard.get_occupancy() ^ (1ull << from) ^ (1ull << to);
+    std::uint64_t occupancy = chessboard.get_occupancy() ^ (1ull << from) ^ (1ull << to) ;
 
     std::uint64_t attackers = chessboard.attackers<White>(to) | chessboard.attackers<Black>(to);
 

--- a/search/move_ordering/see.hpp
+++ b/search/move_ordering/see.hpp
@@ -4,7 +4,7 @@
 #include <cstdint>
 #include "../../chess_board/board.hpp"
 
-constexpr std::int32_t SEE_VALUES[7] = {100, 450, 450, 650, 1250, 30'000, 0};
+constexpr std::int32_t SEE_VALUES[7] = {100, 300, 300, 450, 900, 30'000, 0};
 
 template <Color color>
 static bool see(board & chessboard, const chess_move & capture, int threshold = 0)  {
@@ -12,9 +12,12 @@ static bool see(board & chessboard, const chess_move & capture, int threshold = 
     Square to   = capture.get_to();
 
     Piece piece = chessboard.get_piece(from);
+    
+    /*
     if (piece == Pawn || piece == King) {
         return true;
     }
+    */
 
     int side_to_capture = color ^ 1;
 
@@ -32,7 +35,7 @@ static bool see(board & chessboard, const chess_move & capture, int threshold = 
     rooks   |= queens;
     bishops |= queens;
 
-    std::uint64_t occupancy = chessboard.get_occupancy() ^ (1ull << from) ^ (1ull << to) ;
+    std::uint64_t occupancy = chessboard.get_occupancy() ^ (1ull << from) ^ (1ull << to);
 
     std::uint64_t attackers = chessboard.attackers<White>(to) | chessboard.attackers<Black>(to);
 

--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -20,7 +20,7 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
     std::int16_t eval = evaluate<color>(chessboard);
 
     if (eval >= beta) {
-        return beta;
+        return eval;
     }
 
     if (eval > alpha) {

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -148,7 +148,6 @@ std::int16_t alpha_beta(board & chessboard, search_data & data, std::int16_t alp
                 if (depth < 3 && chessmove.get_score() < 5000 - depth * 500) {
                     break;
                 }
-              
             }
         }
 
@@ -190,6 +189,7 @@ std::int16_t alpha_beta(board & chessboard, search_data & data, std::int16_t alp
 
         if (score > best_score) {
             best_score = score;
+            best_move = chessmove;
             data.update_pv(chessmove);
 
             if (score > alpha) {

--- a/search/search_data.hpp
+++ b/search/search_data.hpp
@@ -66,11 +66,11 @@ public:
     }
 
     void update_history(std::uint8_t from, std::uint8_t to, std::int8_t depth, std::int8_t sequence){
-        history_table.increase_value(from, to, (depth + sequence / 3) * depth);
+        history_table.increase_value(from, to, depth * depth);
     }
 
     void reduce_history(std::uint8_t from, std::uint8_t to, std::int8_t depth, std::int8_t sequence){
-        history_table.reduce_value(from, to, (depth + sequence / 3) * depth);
+        history_table.reduce_value(from, to, depth * depth);
     }
 
     std::uint16_t get_history(std::uint8_t from, std::uint8_t to) {
@@ -82,7 +82,7 @@ public:
     }
 
     std::uint64_t nodes() {
-        return nodes_searched;
+        return timekeeper.get_total_nodes();
     }
 
     void reset_nodes() {

--- a/search/time_keeper.hpp
+++ b/search/time_keeper.hpp
@@ -85,6 +85,10 @@ public:
         return 0;
     }
 
+    std::uint64_t get_total_nodes() {
+        return total_nodes;
+    }
+
     void stop_timer() {
         stop = true;
     }


### PR DESCRIPTION
These changes fix bugs that I found after bug that appeared in D10 trials, particularly in the Motor - Oxidation game. Also added several fixes and new features in UCI and fixed printing of pv lines.

[Fail-soft qs](https://github.com/martinnovaak/motor/commit/1e2da56379a0b2f9a6fcd908cb0a9205d91d7a7c):
Score of dev vs old: 205 - 127 - 607  [0.542] 939
...      dev playing White: 112 - 49 - 310  [0.567] 471
...      dev playing Black: 93 - 78 - 297  [0.516] 468
...      White vs Black: 190 - 142 - 607  [0.526] 939
Elo difference: 28.9 +/- 13.2, LOS: 100.0 %, DrawRatio: 64.6 %
SPRT: llr 2.97 (100.8%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match 

[TT move ordering bug fix](https://github.com/martinnovaak/motor/commit/80823e16350444b72aa29cbaf5b6f2321c7d4b74):
 Score of dev vs old: 155 - 59 - 223  [0.610] 437
...      dev playing White: 86 - 24 - 109  [0.642] 219
...      dev playing Black: 69 - 35 - 114  [0.578] 218
...      White vs Black: 121 - 93 - 223  [0.532] 437
Elo difference: 77.6 +/- 22.7, LOS: 100.0 %, DrawRatio: 51.0 %
SPRT: llr 2.95 (100.2%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match

[Zobrist key update bug](https://github.com/martinnovaak/motor/commit/920be5e59981c6f4185683ee03b2f6bb326ba32b):
Score of dev vs old: 1833 - 1672 - 2706  [0.513] 6211
...      dev playing White: 960 - 771 - 1374  [0.530] 3105
...      dev playing Black: 873 - 901 - 1332  [0.495] 3106
...      White vs Black: 1861 - 1644 - 2706  [0.517] 6211
Elo difference: 9.0 +/- 6.5, LOS: 99.7 %, DrawRatio: 43.6 %
SPRT: llr 2.97 (100.8%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match
