### PR TITLE
tt in qs

### DIFF
--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -19,6 +19,21 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
 
     std::int16_t eval = evaluate<color>(chessboard);
 
+    Bound flag = Bound::UPPER;
+
+    std::uint64_t zobrist_key = chessboard.get_hash_key();
+    const TT_entry& tt_entry = tt[zobrist_key];
+
+    if (tt_entry.zobrist == zobrist_key) {
+        std::int16_t tt_eval = tt_entry.score;
+        eval = tt_eval;
+        if ((tt_entry.bound == Bound::EXACT) ||
+            (tt_entry.bound == Bound::LOWER && tt_eval >= beta) ||
+            (tt_entry.bound == Bound::UPPER && tt_eval <= alpha)) {
+            return tt_eval;
+        }
+    }
+
     if (eval >= beta) {
         return eval;
     }
@@ -31,6 +46,8 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
     generate_all_moves<color, true>(chessboard, movelist);
     qs_score_moves(chessboard, movelist);
 
+    chess_move best_move;
+
     for (std::uint8_t moves_searched = 0; moves_searched < movelist.size(); moves_searched++) {
         chess_move & chessmove = movelist.get_next_move(moves_searched);
 
@@ -42,12 +59,20 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
         std::int16_t score = -quiescence_search<enemy_color>(chessboard, data, -beta, -alpha);
         undo_move<color>(chessboard);
 
-        eval = std::max(eval, score);
+        if (score <= eval) {
+            continue;
+        }
+
+        eval = score;
+        best_move = chessmove;
+
         if (eval >= beta) {
+          //  bound = Bound::LOWER;
             break;
         }
         alpha = std::max(eval, alpha);
     }
+
 
     return eval;
 }

--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -66,14 +66,18 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
         eval = score;
         best_move = chessmove;
 
-        if (eval >= beta) {
-          //  bound = Bound::LOWER;
+        if (beta <= eval) {
+            flag = Bound::LOWER;
             break;
         }
-        alpha = std::max(eval, alpha);
+
+        if (alpha <= eval) {
+            alpha = eval;
+            flag = Bound::EXACT;
+        }
     }
 
-
+    tt[zobrist_key] = { flag, 0, eval, best_move, zobrist_key };
     return eval;
 }
 


### PR DESCRIPTION
Saving results into tt in qs: 
Score of dev vs old: 249 - 159 - 584  [0.545] 992
...      dev playing White: 141 - 76 - 280  [0.565] 497
...      dev playing Black: 108 - 83 - 304  [0.525] 495
...      White vs Black: 224 - 184 - 584  [0.520] 992
Elo difference: 31.6 +/- 13.8, LOS: 100.0 %, DrawRatio: 58.9 %
SPRT: llr 2.95 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match

tt pruning in qs: 
Score of dev vs old: 206 - 107 - 345  [0.575] 658
...      dev playing White: 107 - 51 - 172  [0.585] 330
...      dev playing Black: 99 - 56 - 173  [0.566] 328
...      White vs Black: 163 - 150 - 345  [0.510] 658
Elo difference: 52.7 +/- 18.3, LOS: 100.0 %, DrawRatio: 52.4 %
SPRT: llr 2.96 (100.5%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match
