### PR TITLE
New faster generator

### DIFF
--- a/chess_board/chess_move.hpp
+++ b/chess_board/chess_move.hpp
@@ -34,51 +34,28 @@ enum MoveType : std::uint16_t {
     QUEEN_PROMOTION_CAPTURE  = 15,
 };
 
-enum Check_type : uint8_t {
-    NOCHECK         = 0b00,
-    DIRECT_CHECK    = 0b01,
-    DISCOVERY_CHECK = 0b10,
-    DOUBLE_CHECK    = 0b11,
-};
-
 class chess_move {
 public:
-    chess_move() : move_data{} {}
+    chess_move() : packed_move_data{} {}
 
     chess_move(Square from, Square to, MoveType move_type) {
-        move_data = from | to << 6 | move_type << 12;
-    }
-
-    chess_move(Square from, Square to, MoveType move_type, bool direct_check, bool discovery) {
-        move_data = from | to << 6 | move_type << 12 | direct_check << 16 | discovery << 17;
+        packed_move_data = from | to << 6 | move_type << 12;
     }
 
     [[nodiscard]] Square get_from() const {
-        return static_cast<Square>((move_data) & 0b111111);
+        return static_cast<Square>((packed_move_data) & 0b111111);
     }
 
     [[nodiscard]] Square get_to() const {
-        return static_cast<Square>((move_data >> 6) & 0b111111);
+        return static_cast<Square>((packed_move_data >> 6) & 0b111111);
     }
 
     [[nodiscard]] MoveType get_move_type() const {
-        return static_cast<MoveType>((move_data >> 12) & 0b1111);
-    }
-
-    [[nodiscard]] Check_type get_check_type() const {
-        return static_cast<Check_type>((move_data >> 16) & 0b11);
+        return static_cast<MoveType>((packed_move_data >> 12) & 0b1111);
     }
 
     bool operator==(const chess_move & other_move) const {
-        return other_move.move_data == move_data;
-    }
-
-    bool operator>(const chess_move & other_move) const {
-        return move_data > other_move.move_data;
-    }
-
-    std::uint32_t get_value() {
-        return move_data;
+        return other_move.packed_move_data == packed_move_data;
     }
 
     [[nodiscard]] bool is_quiet() const {
@@ -87,39 +64,18 @@ public:
             case DOUBLE_PAWN_PUSH:
             case KING_CASTLE:
             case QUEEN_CASTLE:
-                return true;
-            case CAPTURE:
-            case EN_PASSANT:
             case KNIGHT_PROMOTION:
             case BISHOP_PROMOTION:
             case ROOK_PROMOTION:
-            case QUEEN_PROMOTION:
             case KNIGHT_PROMOTION_CAPTURE:
             case BISHOP_PROMOTION_CAPTURE:
             case ROOK_PROMOTION_CAPTURE:
+                return true;
+            case CAPTURE:
+            case EN_PASSANT:
+            case QUEEN_PROMOTION:
             case QUEEN_PROMOTION_CAPTURE:
                 return false;
-        }
-    }
-
-    [[nodiscard]] bool is_capture() const {
-        switch (get_move_type()) {
-        case QUIET:
-        case DOUBLE_PAWN_PUSH:
-        case KING_CASTLE:
-        case QUEEN_CASTLE:
-        case EN_PASSANT:
-        case KNIGHT_PROMOTION:
-        case BISHOP_PROMOTION:
-        case ROOK_PROMOTION:
-        case QUEEN_PROMOTION:
-            return false;
-        case CAPTURE:
-        case KNIGHT_PROMOTION_CAPTURE:
-        case BISHOP_PROMOTION_CAPTURE:
-        case ROOK_PROMOTION_CAPTURE:
-        case QUEEN_PROMOTION_CAPTURE:
-            return true;
         }
     }
 
@@ -144,45 +100,38 @@ public:
         }
     }
 
+    [[nodiscard]] bool is_capture() const {
+        return !is_quiet();
+    }
+
     [[nodiscard]] std::string to_string() const {
         std::string move_string;
         move_string.append(square_to_string[get_from()]);
         move_string.append(square_to_string[get_to()]);
-        MoveType mt = get_move_type();
-        switch (mt)
+        switch (get_move_type())
         {
-            case KING_CASTLE:
-                move_string = "";
-                move_string.append(square_to_string[get_from() - 3]);
-                move_string.append(square_to_string[get_to()   + 1]);
-                return move_string;
-            case QUEEN_CASTLE:
-                move_string = "";
-                move_string.append(square_to_string[get_from() + 4]);
-                move_string.append(square_to_string[get_to()   - 1]);
-                return move_string;
             case KNIGHT_PROMOTION:
-                return move_string + "n";
-            case BISHOP_PROMOTION:
-                return move_string + "b";
-            case ROOK_PROMOTION:
-                return move_string + "r";
-            case QUEEN_PROMOTION:
-                return move_string + "q";
             case KNIGHT_PROMOTION_CAPTURE:
                 return move_string + "n";
+            case BISHOP_PROMOTION:
             case BISHOP_PROMOTION_CAPTURE:
                 return move_string + "b";
+            case ROOK_PROMOTION:
             case ROOK_PROMOTION_CAPTURE:
                 return move_string + "r";
+            case QUEEN_PROMOTION:
             case QUEEN_PROMOTION_CAPTURE:
                 return move_string + "q";
             default:
                 return move_string;
         }
     }
+
+    [[nodiscard]] std::uint16_t get_value() const {
+        return packed_move_data;
+    }
 private:
-    std::uint32_t move_data = 0;
+    std::uint16_t packed_move_data = 0;
 };
 
 #endif //MOTOR_CHESS_MOVE_HPP

--- a/cli/uci.hpp
+++ b/cli/uci.hpp
@@ -17,9 +17,9 @@
 bool parse_move(board & b, const std::string& move_string) {
     move_list ml;
     if (b.get_side() == White) {
-        generate_all_moves<White, GenType::ALL>(b, ml);
+        generate_all_moves<White, false>(b, ml);
     } else {
-        generate_all_moves<Black, GenType::ALL>(b, ml);
+        generate_all_moves<Black, false>(b, ml);
     }
 
     for (const chess_move & m : ml) {

--- a/move_generation/move_generator.hpp
+++ b/move_generation/move_generator.hpp
@@ -20,14 +20,8 @@ constexpr std::uint64_t shift(std::uint64_t bitboard) {
     }
 }
 
-enum GenType {
-    ALL, CHECKS_AND_CAPTURES, CAPTURES 
-};
-
-template <Color our_color, GenType type, bool vertical_discovery, bool nonvertical_discovery>
-void generate_pawn_moves(const board & chessboard, move_list & movelist, std::uint64_t pawn_bitboard, std::uint64_t checkmask,
-                         std::uint64_t move_v, std::uint64_t move_a, std::uint64_t move_d, std::uint64_t enemy, std::uint64_t empty, std::uint64_t check_squares)
-{
+template <Color our_color, bool captures_only>
+void generate_pawn_moves(const board & b, move_list & ml, std::uint64_t pawn_bitboard, std::uint64_t checkmask, std::uint64_t move_v, std::uint64_t move_a, std::uint64_t move_d, std::uint64_t enemy, std::uint64_t empty) {
     constexpr Color their_color = (our_color == White) ? Black : White;
     constexpr std::uint64_t penultimate_rank = (our_color == White ? ranks[RANK_7] : ranks[RANK_2]);
     constexpr std::uint64_t not_penultimate_rank = (our_color == White) ? 0xFF00FFFFFFFFFFFFull : 0xFFFFFFFFFFFF00FFull;
@@ -36,8 +30,8 @@ void generate_pawn_moves(const board & chessboard, move_list & movelist, std::ui
     constexpr Direction up_2 = (our_color == White ? NORTH_2 : SOUTH_2);
     constexpr Direction antidiagonal_capture   = (our_color == White ? NORTH_WEST : SOUTH_EAST);
     constexpr Direction diagonal_capture       = (our_color == White ? NORTH_EAST : SOUTH_WEST);
-
-    constexpr bool discovery = (vertical_discovery || nonvertical_discovery);
+    constexpr Direction antidiagonal_enpassant = (our_color == Black ? NORTH_WEST : SOUTH_EAST);
+    constexpr Direction diagonal_enpassant     = (our_color == Black ? NORTH_EAST : SOUTH_WEST);
 
     const std::uint64_t pawns_penultimate     = pawn_bitboard & penultimate_rank;
     const std::uint64_t pawns_not_penultimate = pawn_bitboard & not_penultimate_rank;
@@ -46,335 +40,165 @@ void generate_pawn_moves(const board & chessboard, move_list & movelist, std::ui
     const std::uint64_t threat_squares   = enemy & checkmask;
 
     // PAWN PUSH
-    if constexpr (type == GenType::ALL || type == GenType::CHECKS_AND_CAPTURES) {
+    if constexpr (!captures_only) {
         std::uint64_t bitboard_push_1 = shift<up>(pawns_not_penultimate & move_v) & empty;
         std::uint64_t bitboard_push_2 = shift<up>(bitboard_push_1 & enpassant_rank) & blocking_squares;
 
         bitboard_push_1 &= checkmask;
 
-        std::uint64_t push1_check = check_squares & bitboard_push_1;
-        std::uint64_t push2_check = check_squares & bitboard_push_2;
-
-        while (push1_check) {
-            Square pawn_square = pop_lsb(push1_check);
-            movelist.add(chess_move(pawn_square - up, pawn_square, MoveType::QUIET, true, nonvertical_discovery));
+        while (bitboard_push_1) {
+            Square pawn_square = pop_lsb(bitboard_push_1);
+            ml.add(chess_move(pawn_square - up, pawn_square, MoveType::QUIET));
         }
 
-        while (push2_check) {
-            Square pawn_square = pop_lsb(push2_check);
-            movelist.add(chess_move(pawn_square - up_2, pawn_square, MoveType::DOUBLE_PAWN_PUSH, true, nonvertical_discovery));
-        }
-
-        if constexpr (type == GenType::ALL) {
-            bitboard_push_1 &= ~check_squares;
-            bitboard_push_2 &= ~check_squares;
-
-            while (bitboard_push_1) {
-                Square pawn_square = pop_lsb(bitboard_push_1);
-                movelist.add(chess_move(pawn_square - up, pawn_square, MoveType::QUIET, false, nonvertical_discovery));
-            }
-
-            while (bitboard_push_2) {
-                Square pawn_square = pop_lsb(bitboard_push_2);
-                movelist.add(chess_move(pawn_square - up_2, pawn_square, MoveType::DOUBLE_PAWN_PUSH, false, nonvertical_discovery));
-            }
+        while (bitboard_push_2) {
+            Square pawn_square = pop_lsb(bitboard_push_2);
+            ml.add(chess_move(pawn_square - up_2, pawn_square, MoveType::DOUBLE_PAWN_PUSH));
         }
     }
 
     // PAWNS PROMOTE
     if (pawns_penultimate)
     {
-        std::uint64_t enemy_king = chessboard.get_pieces(their_color, King);
-        std::uint64_t occupancy = ~empty;
-
         std::uint64_t bitboard_promote_push = shift<up>(pawns_penultimate & move_v) & blocking_squares;
         std::uint64_t bitboard_promote_antidiagonal = shift<antidiagonal_capture>(pawns_penultimate & move_a) & threat_squares;
         std::uint64_t bitboard_promote_diagonal = shift<diagonal_capture>(pawns_penultimate & move_d) & threat_squares;
 
         while (bitboard_promote_push) {
             Square pawn_square = pop_lsb(bitboard_promote_push);
-            Square pawn_square_from = pawn_square - up;
-            pop_bit(occupancy, pawn_square_from);
-            bool promote_rook_check = attacks<Ray::ROOK>(pawn_square, occupancy) & enemy_king;
-            bool promote_bishop_check = attacks<Ray::BISHOP>(pawn_square, occupancy) & enemy_king;
-            bool promote_queen_check = promote_bishop_check | promote_rook_check;
-            set_bit(occupancy, pawn_square_from);
-
-            movelist.add(chess_move(pawn_square_from, pawn_square, QUEEN_PROMOTION, promote_queen_check, nonvertical_discovery));
-            if constexpr (type == GenType::ALL) {
-                bool promote_knight_check = KNIGHT_ATTACKS[pawn_square] & enemy_king;
-                movelist.add(chess_move(pawn_square_from, pawn_square, ROOK_PROMOTION, promote_rook_check, nonvertical_discovery));
-                movelist.add(chess_move(pawn_square_from, pawn_square, BISHOP_PROMOTION, promote_bishop_check, nonvertical_discovery));
-                movelist.add(chess_move(pawn_square_from, pawn_square, KNIGHT_PROMOTION, promote_knight_check, nonvertical_discovery));
+            ml.add(chess_move(static_cast<Square>(pawn_square - up), pawn_square, QUEEN_PROMOTION));
+            if constexpr (!captures_only) {
+                ml.add(chess_move(pawn_square - up, pawn_square, ROOK_PROMOTION));
+                ml.add(chess_move(pawn_square - up, pawn_square, BISHOP_PROMOTION));
+                ml.add(chess_move(pawn_square - up, pawn_square, KNIGHT_PROMOTION));
             }
         }
 
         while (bitboard_promote_antidiagonal) {
             Square pawn_square = pop_lsb(bitboard_promote_antidiagonal);
-            Square pawn_square_from = pawn_square - antidiagonal_capture;
-            pop_bit(occupancy, pawn_square_from);
-            bool promote_rook_check = attacks<Ray::ROOK>(pawn_square, occupancy) & enemy_king;
-            bool promote_bishop_check = attacks<Ray::BISHOP>(pawn_square, occupancy) & enemy_king;
-            bool promote_queen_check = promote_bishop_check | promote_rook_check;
-            set_bit(occupancy, pawn_square_from);
-            movelist.add(chess_move(pawn_square_from, pawn_square, QUEEN_PROMOTION_CAPTURE, promote_queen_check, discovery));
-            if constexpr (type == GenType::ALL) {
-                bool promote_knight_check = KNIGHT_ATTACKS[pawn_square] & enemy_king;
-                movelist.add(chess_move(pawn_square_from, pawn_square, ROOK_PROMOTION_CAPTURE, promote_rook_check, discovery));
-                movelist.add(chess_move(pawn_square_from, pawn_square, BISHOP_PROMOTION_CAPTURE, promote_bishop_check, discovery));
-                movelist.add(chess_move(pawn_square_from, pawn_square, KNIGHT_PROMOTION_CAPTURE, promote_knight_check, discovery));
+            ml.add(chess_move(pawn_square - antidiagonal_capture, pawn_square, QUEEN_PROMOTION_CAPTURE));
+            if constexpr (!captures_only) {
+                ml.add(chess_move(pawn_square - antidiagonal_capture, pawn_square, ROOK_PROMOTION_CAPTURE));
+                ml.add(chess_move(pawn_square - antidiagonal_capture, pawn_square, BISHOP_PROMOTION_CAPTURE));
+                ml.add(chess_move(pawn_square - antidiagonal_capture, pawn_square, KNIGHT_PROMOTION_CAPTURE));
             }
         }
 
         while (bitboard_promote_diagonal) {
             Square pawn_square = pop_lsb(bitboard_promote_diagonal);
-            Square pawn_square_from = pawn_square - diagonal_capture;
-            pop_bit(occupancy, pawn_square_from);
-            bool promote_rook_check = attacks<Ray::ROOK>(pawn_square, occupancy) & enemy_king;
-            bool promote_bishop_check = attacks<Ray::BISHOP>(pawn_square, occupancy) & enemy_king;
-            bool promote_queen_check = promote_bishop_check | promote_rook_check;
-            set_bit(occupancy, pawn_square_from);
-            movelist.add(chess_move(pawn_square_from, pawn_square, QUEEN_PROMOTION_CAPTURE, promote_queen_check, discovery));
-            if constexpr (type == GenType::ALL) {
-                bool promote_knight_check = KNIGHT_ATTACKS[pawn_square] & enemy_king;
-                movelist.add(chess_move(pawn_square_from, pawn_square, ROOK_PROMOTION_CAPTURE, promote_rook_check, discovery));
-                movelist.add(chess_move(pawn_square_from, pawn_square, BISHOP_PROMOTION_CAPTURE, promote_bishop_check, discovery));
-                movelist.add(chess_move(pawn_square_from, pawn_square, KNIGHT_PROMOTION_CAPTURE, promote_knight_check, discovery));
+            ml.add(chess_move(pawn_square - diagonal_capture, pawn_square, QUEEN_PROMOTION_CAPTURE));
+            if constexpr (!captures_only) {
+                ml.add(chess_move(pawn_square - diagonal_capture, pawn_square, ROOK_PROMOTION_CAPTURE));
+                ml.add(chess_move(pawn_square - diagonal_capture, pawn_square, BISHOP_PROMOTION_CAPTURE));
+                ml.add(chess_move(pawn_square - diagonal_capture, pawn_square, KNIGHT_PROMOTION_CAPTURE));
             }
         }
     }
 
     // PAWN CAPTURES
-    // Pawn captures can give "all types" of discovery attacks (diagonal capture cannot give diagonal discovery but that pawn wouldn't even be in discovery square)
     std::uint64_t bitboard_left_capture = shift<antidiagonal_capture>(pawns_not_penultimate & move_a) & threat_squares;
     std::uint64_t bitboard_right_capture = shift<diagonal_capture>(pawns_not_penultimate & move_d) & threat_squares;
 
-    std::uint64_t left_capture_checks = bitboard_left_capture & check_squares;
-    std::uint64_t right_capture_checks = bitboard_right_capture & check_squares;
-
-    // PAWN CAPTURES can give double checks only in vertical_discovery
-    while(left_capture_checks) {
-        Square pawn_square = pop_lsb(left_capture_checks);
-        movelist.add(chess_move(pawn_square - antidiagonal_capture, pawn_square, CAPTURE, true, vertical_discovery));
-    }
-
-    while(right_capture_checks) {
-        Square pawn_square = pop_lsb(right_capture_checks);
-        movelist.add(chess_move(pawn_square - diagonal_capture, pawn_square, CAPTURE, true, vertical_discovery));
-    }
-
-    bitboard_left_capture  &= ~check_squares;
-    bitboard_right_capture &= ~check_squares;
-
-    // Pawn captures can give "all types" of discovery attacks
-    // diagonal capture cannot give diagonal discovery but that pawn wouldn't even be in discovery square
     while(bitboard_left_capture) {
         Square pawn_square = pop_lsb(bitboard_left_capture);
-        movelist.add(chess_move(pawn_square - antidiagonal_capture, pawn_square, CAPTURE, false, discovery));
+        ml.add(chess_move(pawn_square - antidiagonal_capture, pawn_square, CAPTURE));
     }
 
-    while (bitboard_right_capture) {
+    while(bitboard_right_capture) {
         Square pawn_square = pop_lsb(bitboard_right_capture);
-        movelist.add(chess_move(pawn_square - diagonal_capture, pawn_square, CAPTURE, false, discovery));
+        ml.add(chess_move(pawn_square - diagonal_capture, pawn_square, CAPTURE));
     }
 
     // EN PASSANT
-    // checking for enpassant discovery attacks is so shitty
-    // TODO: needs refactor for sure
-    Square enpassant_square = chessboard.enpassant_square();
-    Square pawn_to_capture = enpassant_square - up;
+    Square enpassant_square = b.enpassant_square();
     if (enpassant_square != Square::Null_Square)
     {
         std::uint64_t enpassant_bitboard = (1ull << enpassant_square);
-        if ((enpassant_bitboard & checkmask) == 0ull && (1ull << pawn_to_capture) != checkmask) {
-            return;
-        }
-        bool direct_check = enpassant_bitboard & check_squares; // Direct check
-
-        std::uint64_t enemy_king = chessboard.get_pieces(their_color, King);
-        std::uint64_t occupancy = ~empty | enpassant_bitboard;
-        Square enemy_king_square = lsb(enemy_king);
-
         std::uint64_t enpassant_antidiagonal = shift<antidiagonal_capture>(pawns_not_penultimate & move_a) & enpassant_bitboard;
-        Square square_from = enpassant_square - antidiagonal_capture;
-        if(enpassant_antidiagonal && chessboard.check_legality_of_enpassant<their_color>(square_from, pawn_to_capture)) {
-            if constexpr (vertical_discovery) {
-                pop_bit(occupancy, pawn_to_capture);
-                pop_bit(occupancy, square_from);
-                std::uint64_t queen_bitboard = chessboard.get_pieces(our_color, Queen);
-                std::uint64_t bitboard_ad = chessboard.get_pieces(our_color, Bishop) | queen_bitboard;
-                // 6r1/2q2p2/1PB2k2/3P1Pp1/5Q1B/8/6K1/7R w - g6 0 56
-                bool direct_discovery = direct_check || bitboard_ad & attacks<Ray::BISHOP>(enemy_king_square, occupancy);
-                set_bit(occupancy, square_from);
-                set_bit(occupancy, pawn_to_capture);
-                movelist.add(chess_move(square_from, enpassant_square, EN_PASSANT, direct_discovery, vertical_discovery));
-            } else {
-                pop_bit(occupancy, pawn_to_capture);
-                pop_bit(occupancy, square_from);
-                std::uint64_t queen_bitboard = chessboard.get_pieces(our_color, Queen);
-                std::uint64_t bitboard_hv = chessboard.get_pieces(our_color, Rook)   | queen_bitboard;
-                std::uint64_t bitboard_ad = chessboard.get_pieces(our_color, Bishop) | queen_bitboard;
-                bool discovers_attack = bitboard_hv & attacks<Ray::HORIZONTAL>(enemy_king_square, occupancy);
-                discovers_attack = discovers_attack || bitboard_ad & attacks<Ray::BISHOP>(enemy_king_square, occupancy);
-                set_bit(occupancy, square_from);
-                set_bit(occupancy, pawn_to_capture);
-                movelist.add(chess_move(square_from, enpassant_square, EN_PASSANT, direct_check, discovers_attack));
-            }
+        if(enpassant_antidiagonal && b.check_legality_of_enpassant<their_color>(enpassant_square - antidiagonal_capture, enpassant_square - up)) {
+            ml.add(chess_move(enpassant_square - antidiagonal_capture, enpassant_square, EN_PASSANT));
         }
-
         std::uint64_t enpassant_diagonal = shift<diagonal_capture>(pawns_not_penultimate & move_d) & enpassant_bitboard;
-        square_from = enpassant_square - diagonal_capture;
-        if(enpassant_diagonal && chessboard.check_legality_of_enpassant<their_color>(square_from, pawn_to_capture)) {
-            if constexpr (vertical_discovery) {
-                pop_bit(occupancy, pawn_to_capture);
-                pop_bit(occupancy, square_from);
-                std::uint64_t queen_bitboard = chessboard.get_pieces(our_color, Queen);
-                std::uint64_t bitboard_ad = chessboard.get_pieces(our_color, Bishop) | queen_bitboard;
-                // 6r1/2q2p2/1PB2k2/3P1Pp1/5Q1B/8/6K1/7R w - g6 0 56
-                bool direct_discovery = direct_check || bitboard_ad & attacks<Ray::BISHOP>(enemy_king_square, occupancy);
-                set_bit(occupancy, square_from);
-                set_bit(occupancy, pawn_to_capture);
-                movelist.add(chess_move(square_from, enpassant_square, EN_PASSANT, direct_discovery, vertical_discovery));
-            } else {
-                pop_bit(occupancy, pawn_to_capture);
-                pop_bit(occupancy, square_from);
-                std::uint64_t queen_bitboard = chessboard.get_pieces(our_color, Queen);
-                std::uint64_t bitboard_hv = chessboard.get_pieces(our_color, Rook)   | queen_bitboard;
-                std::uint64_t bitboard_ad = chessboard.get_pieces(our_color, Bishop) | queen_bitboard;
-                bool discovers_attack = bitboard_hv & attacks<Ray::HORIZONTAL>(enemy_king_square, occupancy);
-                discovers_attack = discovers_attack || bitboard_ad & attacks<Ray::BISHOP>(enemy_king_square, occupancy);
-                set_bit(occupancy, square_from);
-
-
-                movelist.add(chess_move(square_from, enpassant_square, EN_PASSANT, direct_check, discovers_attack));
-            }
+        if(enpassant_diagonal && b.check_legality_of_enpassant<their_color>(enpassant_square - diagonal_capture, enpassant_square - up)) {
+            ml.add(chess_move(enpassant_square - diagonal_capture, enpassant_square, EN_PASSANT));
         }
     }
 }
 
-template <GenType type, bool discovery>
-constexpr void generate_knight_moves(const board & b, move_list & ml, std::uint64_t knight_bitboard, std::uint64_t target, std::uint64_t enemy, std::uint64_t empty, std::uint64_t occupancy, std::uint64_t knight_checks)
+template <Color our_color, bool captures_only>
+void generate_knight_moves(const board & b, move_list & ml, std::uint64_t knight_bitboard, std::uint64_t target, std::uint64_t enemy, std::uint64_t empty, std::uint64_t occupancy)
 {
     while(knight_bitboard) {
         Square square = pop_lsb(knight_bitboard);
         std::uint64_t attack_bitboard = KNIGHT_ATTACKS[square] & target;
 
         std::uint64_t captures = attack_bitboard & enemy;
-
-        std::uint64_t check_captures = captures & knight_checks;
-        captures &= ~knight_checks;
-
-        while (check_captures) {
-            Square target_square = pop_lsb(check_captures);
-            ml.add(chess_move(square, target_square, CAPTURE, true, discovery));
-        }
-
         while(captures) {
             Square target_square = pop_lsb(captures);
-            ml.add(chess_move(square, target_square, CAPTURE, false, discovery));
+            ml.add(chess_move(square, target_square, CAPTURE));
         }
 
-        if constexpr (type == GenType::ALL || type == GenType::CHECKS_AND_CAPTURES) {
+        if constexpr (!captures_only) {
             std::uint64_t quiets = attack_bitboard & empty;
-
-            std::uint64_t quiet_checks = quiets & knight_checks;
-            while (quiet_checks) {
-                Square target_square = pop_lsb(quiet_checks);
-                ml.add(chess_move(square, target_square, QUIET, true, discovery));
-            }
-
-            if constexpr (type == GenType::ALL) {
-                quiets &= ~knight_checks;
-                while (quiets) {
-                    Square target_square = pop_lsb(quiets);
-                    ml.add(chess_move(square, target_square, QUIET, false, discovery));
-                }
+            while (quiets) {
+                Square target_square = pop_lsb(quiets);
+                ml.add(chess_move(square, target_square, QUIET));
             }
         }
     }
 }
 
-template <GenType type>
-constexpr void generate_king_moves(const board & b, move_list & ml, Square king_square, std::uint64_t safe_squares, std::uint64_t empty, std::uint64_t enemy, std::uint64_t discovery_squares)
+template <Color our_color, bool captures_only>
+void generate_king_moves(const board & b, move_list & ml, Square king_square, std::uint64_t safe_squares, std::uint64_t empty, std::uint64_t enemy)
 {
     std::uint64_t king_moves = KING_ATTACKS[king_square] & safe_squares;
 
-    // king has to be on discovery square and has to move outside of discovery square
-    bool king_can_discover = (1ull << king_square) & discovery_squares;
-
     std::uint64_t king_captures = king_moves & enemy;
-
-    // to give discovery check king has to move outside of discovery ray
-    std::uint64_t king_discovery_captures = king_captures & ~discovery_squares;
-
-    while(king_discovery_captures) {
-        Square target_square = pop_lsb(king_discovery_captures);
-        ml.add(chess_move(king_square, target_square, CAPTURE, false, king_can_discover));
-    }
-
-    king_captures &= discovery_squares;
     while (king_captures) {
         Square target_square = pop_lsb(king_captures);
         ml.add(chess_move(king_square, target_square, CAPTURE));
     }
 
-    if constexpr (type == GenType::ALL || type == GenType::CHECKS_AND_CAPTURES) {
+    if constexpr (!captures_only) {
         std::uint64_t king_quiets = king_moves & empty;
-        std::uint64_t quiet_discovery = king_quiets & ~discovery_squares;
-
-        while(quiet_discovery) {
-            Square target_square = pop_lsb(quiet_discovery);
-            ml.add(chess_move(king_square, target_square, QUIET, false, king_can_discover));
-        }
-
-        if constexpr (type == GenType::ALL) {
-            king_quiets &= discovery_squares;
-            while (king_quiets) {
-                Square target_square = pop_lsb(king_quiets);
-                ml.add(chess_move(king_square, target_square, QUIET));
-            }
+        while (king_quiets) {
+            Square target_square = pop_lsb(king_quiets);
+            ml.add(chess_move(king_square, target_square, QUIET));
         }
     }
 }
 
 template <Color our_color>
-constexpr void generate_castle_moves(move_list & ml, int castling_right, std::uint64_t safe_squares, std::uint64_t empty, std::uint64_t check_squares, std::uint64_t horizontal_discovery) {
-    constexpr Square rook_a_square = our_color == White ? A1 : A8;
-    constexpr Square rook_h_square = our_color == White ? H1 : H8;
-    constexpr Square rook_d_square = our_color == White ? D1 : D8;
-    constexpr Square rook_f_square = our_color == White ? F1 : F8;
+void generate_castle_moves(move_list & ml, int castling_right, std::uint64_t safe_squares, std::uint64_t empty) {
+    constexpr Square king_e_square = our_color == White ? E1 : E8;
+    constexpr Square king_g_square = our_color == White ? G1 : G8;
+    constexpr Square king_c_square = our_color == White ? C1 : C8;
 
     constexpr std::uint64_t kingside_castle_efg_mask  = our_color == White ? 0x70ull : 0x7000000000000000ull;
     constexpr std::uint64_t kingside_castle_fg_mask   = our_color == White ? 0x60ull : 0x6000000000000000ull;
     constexpr std::uint64_t queenside_castle_cde_mask = our_color == White ? 0x1cull : 0x1c00000000000000ull;
     constexpr std::uint64_t queenside_castle_bcd_mask = our_color == White ? 0xeull  : 0xe00000000000000ull;
-    constexpr std::uint64_t king_e_mask = our_color == White ? 0x10ull : 0x1000000000000000ull;
 
     constexpr int kingside_castle_right  = our_color == White ? CASTLE_WHITE_KINGSIDE  : CASTLE_BLACK_KINGSIDE;
     constexpr int queenside_castle_right = our_color == White ? CASTLE_WHITE_QUEENSIDE : CASTLE_BLACK_QUEENSIDE;
-
-    constexpr std::uint64_t queenside_check_square = our_color == White ? 0x8ull  : 0x800000000000000ull;
-    constexpr std::uint64_t kingside_check_square  = our_color == White ? 0x20ull : 0x2000000000000000ull;
 
     if(castling_right & kingside_castle_right
        && (safe_squares & kingside_castle_efg_mask) == kingside_castle_efg_mask
        && (empty & kingside_castle_fg_mask) == kingside_castle_fg_mask)
     {
-        bool direct_check = kingside_check_square & check_squares | king_e_mask & horizontal_discovery;
-        ml.add(chess_move(rook_h_square, rook_f_square, KING_CASTLE, direct_check, false));
+        ml.add(chess_move(king_e_square, king_g_square, KING_CASTLE));
     }
 
     if(castling_right & queenside_castle_right
        && (safe_squares & queenside_castle_cde_mask) == queenside_castle_cde_mask
        && (empty & queenside_castle_bcd_mask) == queenside_castle_bcd_mask)
     {
-        bool direct_check = queenside_check_square & check_squares | king_e_mask & horizontal_discovery;
-        ml.add(chess_move(rook_a_square, rook_d_square, QUEEN_CASTLE, direct_check, false));
+        ml.add(chess_move(king_e_square, king_c_square, QUEEN_CASTLE));
     }
 }
 
-template <Ray ray, GenType type, bool discovery>
-constexpr void generate_slider_moves(const board & b, move_list& ml, std::uint64_t piece_bitboard, std::uint64_t checkmask, std::uint64_t enemy, std::uint64_t empty, std::uint64_t occupancy, std::uint64_t check_squares)
+template <Color our_color, Ray ray, Piece piece, bool captures_only>
+void generate_slider_moves(const board & b, move_list& ml, std::uint64_t piece_bitboard, std::uint64_t checkmask, std::uint64_t enemy, std::uint64_t empty, std::uint64_t occupancy)
 {
     while (piece_bitboard) {
         Square square = pop_lsb(piece_bitboard);
@@ -382,45 +206,27 @@ constexpr void generate_slider_moves(const board & b, move_list& ml, std::uint64
 
         std::uint64_t captures = attack_bitboard & enemy;
 
-        std::uint64_t check_captures = captures & check_squares;
-
-        while(check_captures) {
-            Square target_square = pop_lsb(check_captures);
-            ml.add(chess_move(square, target_square, CAPTURE, true, discovery));
-        }
-
-        captures &= ~check_squares;
         while (captures) {
             Square target_square = pop_lsb(captures);
-            ml.add(chess_move(square, target_square, CAPTURE, false, discovery));
+            ml.add(chess_move(square, target_square, CAPTURE));
         }
 
-        if constexpr (type == GenType::ALL) {
+        if constexpr (!captures_only) {
             std::uint64_t quiets = attack_bitboard & empty;
-
-            std::uint64_t quiet_checks = quiets & check_squares;
-
-            while (quiet_checks) {
-                Square target_square = pop_lsb(quiet_checks);
-                ml.add(chess_move(square, target_square,QUIET, true, discovery));
-            }
-
-            quiets &= ~check_squares;
             while (quiets) {
                 Square target_square = pop_lsb(quiets);
-                ml.add(chess_move(square, target_square, QUIET, false, discovery));
+                ml.add(chess_move(square, target_square, QUIET));
             }
         }
     }
 }
 
 
-template <Color our_color, GenType type>
-constexpr void generate_all_moves(board & b, move_list & ml) {
+template <Color our_color, bool captures_only>
+bool generate_all_moves(board & b, move_list & ml) {
     constexpr Color enemy_color = our_color == White ? Black : White;
 
     Square king_square = b.get_king_square();
-    Square enemy_king_square = lsb(b.get_pieces(enemy_color, King));
     const std::uint64_t enemy_pieces = b.get_side_occupancy<enemy_color>();
     const std::uint64_t occupancy = b.get_occupancy();
     const std::uint64_t empty = ~occupancy;
@@ -429,19 +235,7 @@ constexpr void generate_all_moves(board & b, move_list & ml) {
 
     const std::uint64_t checkmask = b.get_checkmask<enemy_color>(king_square);
 
-    std::uint64_t rook_check_squares   = attacks<Ray::ROOK>(enemy_king_square, occupancy);
-    std::uint64_t bishop_check_squares = attacks<Ray::BISHOP>(enemy_king_square, occupancy);
-    std::uint64_t knight_check_squares = KNIGHT_ATTACKS[enemy_king_square];
-    std::uint64_t pawn_check_squares   = PAWN_ATTACKS_TABLE[enemy_color][enemy_king_square];
-    std::uint64_t queen_check_squares  = rook_check_squares | bishop_check_squares;
-
-    auto [discover_h, discover_v, discover_a, discover_d] = b.get_discovering_pieces<our_color>(enemy_king_square, queen_check_squares);
-
-    std::uint64_t discover_hv = discover_h | discover_v;
-    std::uint64_t discover_ad = discover_a | discover_d;
-    std::uint64_t discovery_squares = discover_ad | discover_hv;
-
-    generate_king_moves<type>(b, ml, king_square, safe_squares, empty, enemy_pieces, discovery_squares);
+    generate_king_moves<our_color, captures_only>(b, ml, king_square, safe_squares, empty, enemy_pieces);
 
     const auto [pin_h, pin_v, pin_a, pin_d] = b.get_pinners<our_color, enemy_color>(king_square);
 
@@ -466,51 +260,29 @@ constexpr void generate_all_moves(board & b, move_list & ml) {
     std::uint64_t d_checkmask = checkmask & pin_d;
 
     // non-pinned rooks
-    std::uint64_t nonpinned_rooks = rook_bitboard & ~pin_hv;
-    generate_slider_moves<Ray::ROOK, type, false>(b, ml, nonpinned_rooks & ~discover_ad, checkmask,enemy_pieces, empty, occupancy, rook_check_squares);
-    generate_slider_moves<Ray::ROOK, type, true >(b, ml, nonpinned_rooks &  discover_ad, checkmask,enemy_pieces, empty, occupancy, rook_check_squares);
-
+    generate_slider_moves<our_color, Ray::ROOK, Rook, captures_only>(b, ml, rook_bitboard & ~pin_hv, checkmask,enemy_pieces, empty, occupancy);
     // horizontally/vertically pinned rooks
-    std::uint64_t horizontally_pinned_rooks = rook_bitboard & pin_h;
-    std::uint64_t vertically_pinned_rooks = rook_bitboard & pin_v;
-    generate_slider_moves<Ray::HORIZONTAL, type, false>(b, ml, horizontally_pinned_rooks &~discover_ad, h_checkmask,enemy_pieces, empty, occupancy, rook_check_squares);
-    generate_slider_moves<Ray::VERTICAL, type, false>(b, ml, vertically_pinned_rooks &~discover_ad, v_checkmask,enemy_pieces, empty, occupancy, rook_check_squares);
-
-    generate_slider_moves<Ray::HORIZONTAL, type, true>(b, ml, horizontally_pinned_rooks & discover_ad, h_checkmask,enemy_pieces, empty, occupancy, rook_check_squares);
-    generate_slider_moves<Ray::VERTICAL, type, true>(b, ml, vertically_pinned_rooks & discover_ad, v_checkmask,enemy_pieces, empty, occupancy, rook_check_squares);
+    generate_slider_moves<our_color, Ray::HORIZONTAL, Rook, captures_only>(b, ml, rook_bitboard & pin_h, h_checkmask,enemy_pieces, empty, occupancy);
+    generate_slider_moves<our_color, Ray::VERTICAL, Rook, captures_only>(b, ml, rook_bitboard & pin_v, v_checkmask,enemy_pieces, empty, occupancy);
     // non-pinned bishops
-    std::uint64_t nonpinned_bishops = bishop_bitboard & ~pin_ad;
-    generate_slider_moves<Ray::BISHOP, type, false>(b, ml, nonpinned_bishops & ~discover_hv, checkmask,enemy_pieces, empty, occupancy, bishop_check_squares);
-    generate_slider_moves<Ray::BISHOP, type, true>(b, ml, nonpinned_bishops &  discover_hv, checkmask,enemy_pieces, empty, occupancy, bishop_check_squares);
-
+    generate_slider_moves<our_color, Ray::BISHOP, Bishop, captures_only>(b, ml, bishop_bitboard & ~pin_ad, checkmask,enemy_pieces, empty, occupancy);
     // antidiagonally/diagonally pinned bishops
-    std::uint64_t antidiagonally_pinned_bishops = bishop_bitboard & pin_a;
-    std::uint64_t diagonally_pinned_bishops = bishop_bitboard & pin_d;
-    generate_slider_moves<Ray::ANTIDIAGONAL, type, false>(b, ml, antidiagonally_pinned_bishops & ~discover_hv,a_checkmask, enemy_pieces, empty, occupancy, bishop_check_squares);
-    generate_slider_moves<Ray::DIAGONAL, type, false>(b, ml, diagonally_pinned_bishops & ~discover_hv, d_checkmask,enemy_pieces, empty, occupancy, bishop_check_squares);
-
-    generate_slider_moves<Ray::ANTIDIAGONAL, type, true>(b, ml, antidiagonally_pinned_bishops & discover_hv,a_checkmask, enemy_pieces, empty, occupancy, bishop_check_squares);
-    generate_slider_moves<Ray::DIAGONAL, type, true>(b, ml, diagonally_pinned_bishops & discover_hv, d_checkmask,enemy_pieces, empty, occupancy, bishop_check_squares);
-
+    generate_slider_moves<our_color, Ray::ANTIDIAGONAL, Bishop, captures_only>(b, ml, bishop_bitboard & pin_a,a_checkmask, enemy_pieces, empty,occupancy);
+    generate_slider_moves<our_color, Ray::DIAGONAL, Bishop, captures_only>(b, ml, bishop_bitboard & pin_d, d_checkmask,enemy_pieces, empty, occupancy);
     // non-pinned queens
-    // queen cannot give discovery check
-    generate_slider_moves<Ray::QUEEN, type, false>(b, ml, queen_bitboard & non_pinned_pieces,checkmask, enemy_pieces, empty, occupancy, queen_check_squares);
-    generate_slider_moves<Ray::HORIZONTAL, type, false>(b, ml, queen_bitboard & pin_h, h_checkmask,enemy_pieces, empty, occupancy, queen_check_squares);
-    generate_slider_moves<Ray::VERTICAL, type, false>(b, ml, queen_bitboard & pin_v, v_checkmask,enemy_pieces, empty, occupancy, queen_check_squares);
-    generate_slider_moves<Ray::ANTIDIAGONAL, type, false>(b, ml, queen_bitboard & pin_a,a_checkmask, enemy_pieces, empty,occupancy, queen_check_squares);
-    generate_slider_moves<Ray::DIAGONAL, type, false>(b, ml, queen_bitboard & pin_d, d_checkmask,enemy_pieces, empty, occupancy, queen_check_squares);
+    generate_slider_moves<our_color, Ray::QUEEN, Queen, captures_only>(b, ml, queen_bitboard & non_pinned_pieces,checkmask, enemy_pieces, empty, occupancy);
+    generate_slider_moves<our_color, Ray::HORIZONTAL, Queen, captures_only>(b, ml, queen_bitboard & pin_h, h_checkmask,enemy_pieces, empty, occupancy);
+    generate_slider_moves<our_color, Ray::VERTICAL, Queen, captures_only>(b, ml, queen_bitboard & pin_v, v_checkmask,enemy_pieces, empty, occupancy);
+    generate_slider_moves<our_color, Ray::ANTIDIAGONAL, Queen, captures_only>(b, ml, queen_bitboard & pin_a,a_checkmask, enemy_pieces, empty,occupancy);
+    generate_slider_moves<our_color, Ray::DIAGONAL, Queen, captures_only>(b, ml, queen_bitboard & pin_d, d_checkmask,enemy_pieces, empty, occupancy);
 
-    // Knight can give any type of discovery check
-    generate_knight_moves<type, true >(b, ml, knight_bitboard &  discovery_squares, checkmask, enemy_pieces, empty, occupancy, knight_check_squares);
-    generate_knight_moves<type, false>(b, ml, knight_bitboard & ~discovery_squares, checkmask, enemy_pieces, empty, occupancy, knight_check_squares);
-
-    generate_pawn_moves<our_color, type, false, false>(b, ml, pawn_bitboard & ~discovery_squares, checkmask, ~pin_ad, ~(pin_d | pin_v),~(pin_a | pin_v), enemy_pieces, empty, pawn_check_squares);
-    generate_pawn_moves<our_color, type, true,  false>(b, ml, pawn_bitboard & discover_v, checkmask, ~pin_ad, ~(pin_d | pin_v),~(pin_a | pin_v), enemy_pieces, empty, pawn_check_squares);
-    generate_pawn_moves<our_color, type, false, true>(b, ml, pawn_bitboard & (discover_h | discover_ad), checkmask, ~pin_ad, ~(pin_d | pin_v),~(pin_a | pin_v), enemy_pieces, empty, pawn_check_squares);
-
-    if constexpr (type == GenType::ALL) {
-        generate_castle_moves<our_color>(ml, b.get_castle_rights(), safe_squares, empty, rook_check_squares, discover_h);
+    generate_knight_moves<our_color, captures_only>(b, ml, knight_bitboard, checkmask, enemy_pieces, empty, occupancy);
+    generate_pawn_moves<our_color, captures_only>(b, ml, pawn_bitboard, checkmask, ~pin_ad, ~(pin_d | pin_v),~(pin_a | pin_v), enemy_pieces, empty);
+    if constexpr (!captures_only) {
+        generate_castle_moves<our_color>(ml, b.get_castle_rights(), safe_squares, empty);
     }
+
+    return checkmask == full_board;
 }
 
 #endif //MOTOR_MOVE_GENERATOR_HPP

--- a/search/move_ordering/see.hpp
+++ b/search/move_ordering/see.hpp
@@ -149,10 +149,10 @@ void see_test_suite() {
         board b(fen);
         move_list ml;
         if (b.get_side() == White) {
-            generate_all_moves<White, GenType::ALL>(b, ml);
+            generate_all_moves<White, false>(b, ml);
         }
         else {
-            generate_all_moves<Black, GenType::ALL>(b, ml);
+            generate_all_moves<Black, false>(b, ml);
         }
         
         for (const auto& move : ml) {
@@ -175,7 +175,7 @@ void see_test_suite() {
     }
     std::cout << "FAULTS: " << counter << std::endl;
 
-    for (auto fen : errors) {
+    for (const auto& fen : errors) {
         std::cout << fen << std::endl;
     }
 }

--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -17,7 +17,7 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
         return beta;
     }
 
-    std::int16_t eval = evaluate<color>(chessboard);
+    std::int16_t static_eval, eval;
 
     Bound flag = Bound::UPPER;
 
@@ -26,12 +26,15 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
 
     if (tt_entry.zobrist == zobrist_key) {
         std::int16_t tt_eval = tt_entry.score;
+        static_eval = tt_entry.static_eval;
         eval = tt_eval;
         if ((tt_entry.bound == Bound::EXACT) ||
             (tt_entry.bound == Bound::LOWER && tt_eval >= beta) ||
             (tt_entry.bound == Bound::UPPER && tt_eval <= alpha)) {
             return tt_eval;
         }
+    } else {
+        static_eval = eval = evaluate<color>(chessboard);
     }
 
     if (eval >= beta) {
@@ -43,7 +46,7 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
     }
 
     move_list movelist;
-    generate_all_moves<color, GenType::CAPTURES>(chessboard, movelist);
+    generate_all_moves<color, true>(chessboard, movelist);
     qs_score_moves(chessboard, movelist);
 
     chess_move best_move;
@@ -78,7 +81,7 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
         }
     }
 
-    tt[zobrist_key] = { flag, 0, eval, best_move, zobrist_key };
+    tt[zobrist_key] = { flag, 0, eval, static_eval, best_move, zobrist_key };
     return eval;
 }
 

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -28,6 +28,10 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
         return beta;
     }
 
+    if (data.get_ply() > 92) {
+        return evaluate<color>(chessboard);
+    }
+
     data.update_pv_length();
 
     bool in_check = false;

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -53,8 +53,8 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
     chess_move best_move;
     chess_move tt_move = {};
-    std::int16_t static_eval = evaluate<color>(chessboard);;
-    std::int16_t eval = static_eval;
+    //std::int16_t static_eval = evaluate<color>(chessboard);;
+    std::int16_t eval, static_eval;
     bool tthit = false;
 
     if (data.singular_move == 0 && tt_entry.zobrist == zobrist_key) {
@@ -62,8 +62,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
         tt_move = tt_entry.tt_move;
         std::int16_t tt_eval = tt_entry.score;
         tthit = true;
-        //eval = tt_eval;
-        static_eval = tt_eval;
+        eval = static_eval = tt_entry.static_eval;
         if constexpr (!is_pv) {
             if (tt_entry.depth >= depth) {
                 if ((tt_entry.bound == Bound::EXACT) ||
@@ -80,6 +79,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
         }
     }
     else {
+        eval = static_eval = evaluate<color>(chessboard);
         if (data.singular_move == 0 && depth >= 4) {
             depth--;
         }
@@ -128,7 +128,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
     }
 
     move_list movelist, quiets;
-    generate_all_moves<color, GenType::ALL>(chessboard, movelist);
+    generate_all_moves<color, false>(chessboard, movelist);
 
     if (movelist.size() == 0) {
         if (data.singular_move > 0) return alpha;
@@ -157,7 +157,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
         int reduction = 1.0 + lmr_base * std::log2(moves_searched);
 
         if constexpr (!is_root) {
-            if (moves_searched && best_score > -9'000 && !in_check && movelist[moves_searched] < 15'000 && chessmove.get_check_type() == NOCHECK) {
+            if (moves_searched && best_score > -9'000 && !in_check && movelist[moves_searched] < 15'000) {
                 if (chessmove.is_quiet()) {
                     if (moves_searched > 4 + depth * depth) {
                         continue;
@@ -217,7 +217,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
             if (depth >= 3 && movelist[moves_searched] < 1'000'000) {
                 if (chessmove.is_quiet()) {
                     reduction += !is_pv + !improving;  
-                    reduction -= chessmove.get_check_type() > NOCHECK;
+                    reduction -= chessboard.in_check();
                 } 
 
                 reduction = std::clamp(reduction, 0, depth - 2);
@@ -289,7 +289,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
     }
 
     if (data.singular_move == 0)
-        tt[zobrist_key] = { flag, depth, best_score, best_move, zobrist_key };
+        tt[zobrist_key] = { flag, depth, best_score, static_eval, best_move, zobrist_key };
 
     return best_score;
 }

--- a/search/search_data.hpp
+++ b/search/search_data.hpp
@@ -23,7 +23,8 @@ struct TT_entry {
     Bound bound;            // 8 bits
     std::int8_t depth;      // 8 bits
     std::int16_t score;     // 16 bits
-    chess_move tt_move;     // 32 bits
+    std::int16_t static_eval; // 16 bits
+    chess_move tt_move;     // 16 bits
     std::uint64_t zobrist;  // 64 bits
 };
 


### PR DESCRIPTION
New legal move generator
- removing the precalculation of check on a chess moves generation
- chess move structure now fits 16 bits
- adding static eval (16 bits) into transposition table entry 

8+0.08 test:
```
Score of dev vs old: 650 - 531 - 1181  [0.525] 2362
...      dev playing White: 536 - 74 - 570  [0.696] 1180
...      dev playing Black: 114 - 457 - 611  [0.355] 1182
...      White vs Black: 993 - 188 - 1181  [0.670] 2362
Elo difference: 17.5 +/- 9.9, LOS: 100.0 %, DrawRatio: 50.0 %
SPRT: llr 2.95 (100.1%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match
```