### PR TITLE
Add futility pruning

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -161,7 +161,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
                     int lmr_depth = std::max(0, depth - reduction);
                     if (lmr_depth < 7 && static_eval + 300 + 120 * lmr_depth <= alpha) {
-                    //    continue;
+                        continue;
                     }
                 }
 


### PR DESCRIPTION
Score of dev vs old: 1598 - 1454 - 3380  [0.511] 6432
...      dev playing White: 1360 - 214 - 1643  [0.678] 3217
...      dev playing Black: 238 - 1240 - 1737  [0.344] 3215
...      White vs Black: 2600 - 452 - 3380  [0.667] 6432
Elo difference: 7.8 +/- 5.8, LOS: 99.5 %, DrawRatio: 52.5 %
SPRT: llr 2.97 (100.7%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match