### PR TITLE
History lmr

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -222,6 +222,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
                 if (chessmove.is_quiet()) {
                     reduction += !is_pv + !improving;  
                     reduction -= chessboard.in_check();
+                    reduction -= movelist[moves_searched] / 12'000;
                 } 
 
                 reduction = std::clamp(reduction, 0, depth - 2);


### PR DESCRIPTION
Reduce or extend quiet moves depending on history score

Score of dev vs old: 1237 - 1110 - 3169  [0.512] 5516
...      dev playing White: 1093 - 110 - 1555  [0.678] 2758
...      dev playing Black: 144 - 1000 - 1614  [0.345] 2758
...      White vs Black: 2093 - 254 - 3169  [0.667] 5516
Elo difference: 8.0 +/- 6.0, LOS: 99.6 %, DrawRatio: 57.5 %
SPRT: llr 2.96 (100.4%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match