### PR TITLE
Add improving heuristic into late move pruning

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -155,7 +155,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
         if constexpr (!is_root) {
             if (moves_searched && best_score > -9'000 && !in_check && movelist[moves_searched] < 15'000) {
                 if (chessmove.is_quiet()) {
-                    if (moves_searched > 4 + depth * depth) {
+                    if (quiets.size() > 4 + depth * depth / (2 - improving)) {
                         continue;
                     }
 


### PR DESCRIPTION
Score of dev vs old: 823 - 709 - 2039  [0.516] 3571
...      dev playing White: 743 - 63 - 979  [0.690] 1785
...      dev playing Black: 80 - 646 - 1060  [0.342] 1786
...      White vs Black: 1389 - 143 - 2039  [0.674] 3571
Elo difference: 11.1 +/- 7.5, LOS: 99.8 %, DrawRatio: 57.1 %
SPRT: llr 2.97 (100.8%), lbound -2.94, ubound 2.94 - H1 was accepted
Finished match 