### PR TITLE
nmp tweak

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -139,10 +139,10 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
             }
 
             // NULL MOVE PRUNING
-            if (node_type != NodeType::Null && depth >= nmp_depth && eval >= beta && !chessboard.pawn_endgame()) {
+            if (node_type != NodeType::Null && depth >= nmp_depth && eval >= beta && static_eval >= beta && !chessboard.pawn_endgame()) {
                 chessboard.make_null_move<color>();
                 tt.prefetch(chessboard.get_hash_key());
-                int R = nmp + depth / nmp_div + improving;
+                int R = nmp + depth / nmp_div + improving + std::min((static_eval - beta) / 256, 3);
                 data.augment_ply();
                 std::int16_t nullmove_score = -alpha_beta<enemy_color, NodeType::Null>(chessboard, data, -beta, -alpha, depth - R, !cutnode);
                 data.reduce_ply();


### PR DESCRIPTION
Elo   | 2.84 +- 2.28 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 24352 W: 5798 L: 5599 D: 12955
Penta | [88, 2878, 6053, 3061, 96]

Bench: 4426119