### PR TITLE
Enable TT cutoffs for mate score values

### DIFF
--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -31,7 +31,7 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
     Bound flag = Bound::UPPER;
 
     std::uint64_t zobrist_key = chessboard.get_hash_key();
-    const TT_entry& tt_entry = tt.retrieve(zobrist_key);
+    const TT_entry& tt_entry = tt.retrieve(zobrist_key, data.get_ply());
 
     if (tt_entry.zobrist == tt.upper(zobrist_key)) {
         std::int16_t tt_eval = tt_entry.score;
@@ -100,7 +100,7 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
         }
     }
 
-    tt.store(flag, 0, eval, static_eval, best_move, zobrist_key);
+    tt.store(flag, 0, eval, static_eval, best_move, data.get_ply(), zobrist_key);
     return eval;
 }
 

--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -31,9 +31,9 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
     Bound flag = Bound::UPPER;
 
     std::uint64_t zobrist_key = chessboard.get_hash_key();
-    const TT_entry& tt_entry = tt[zobrist_key];
+    const TT_entry& tt_entry = tt.retrieve(zobrist_key);
 
-    if (tt_entry.zobrist == zobrist_key) {
+    if (tt_entry.zobrist == tt.upper(zobrist_key)) {
         std::int16_t tt_eval = tt_entry.score;
         static_eval = tt_entry.static_eval;
         eval = tt_eval;
@@ -100,7 +100,7 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
         }
     }
 
-    tt[zobrist_key] = { flag, 0, eval, static_eval, best_move, zobrist_key };
+    tt.store(flag, 0, eval, static_eval, best_move, zobrist_key);
     return eval;
 }
 

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -148,7 +148,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
                 data.reduce_ply();
                 chessboard.undo_null_move<color>();
                 if (nullmove_score >= beta) {
-                    return nullmove_score;
+                    return std::abs(nullmove_score) > 19'000 ? beta : nullmove_score;
                 }
             }
         }

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -82,13 +82,13 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
     Bound flag = Bound::UPPER;
 
     std::uint64_t zobrist_key = chessboard.get_hash_key();
-    const TT_entry& tt_entry = tt[zobrist_key];
+    const TT_entry& tt_entry = tt.retrieve(zobrist_key);
 
     chess_move best_move;
     chess_move tt_move = {};
     std::int16_t eval, static_eval, raw_eval;
 
-    if (data.singular_move == 0 && tt_entry.zobrist == zobrist_key) {
+    if (data.singular_move == 0 && tt_entry.zobrist == tt.upper(zobrist_key)) {
         best_move = tt_entry.tt_move;
         tt_move = tt_entry.tt_move;
         std::int16_t tt_eval = tt_entry.score;
@@ -328,7 +328,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
             entry = std::clamp(entry, -16'384, 16'384);
         }
 
-        tt[zobrist_key] = {flag, depth, best_score, raw_eval, best_move, zobrist_key};
+        tt.store(flag, depth, best_score, raw_eval, best_move, zobrist_key);
     }
 
     return best_score;

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -82,7 +82,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
     Bound flag = Bound::UPPER;
 
     std::uint64_t zobrist_key = chessboard.get_hash_key();
-    const TT_entry& tt_entry = tt.retrieve(zobrist_key);
+    const TT_entry& tt_entry = tt.retrieve(zobrist_key, data.get_ply());
 
     chess_move best_move;
     chess_move tt_move = {};
@@ -215,8 +215,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
                 movelist.get_move_score(moves_searched) == 214'748'364 &&
                 tt_entry.depth >= depth - se_depth_margin &&
                 tt_entry.bound != Bound::UPPER &&
-                data.singular_move == 0 &&
-                std::abs(tt_entry.score) < 9'000)
+                data.singular_move == 0)
             {
                 int s_beta = tt_entry.score - se_mul * depth / 80;
                 data.singular_move = chessmove.get_value();
@@ -328,7 +327,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
             entry = std::clamp(entry, -16'384, 16'384);
         }
 
-        tt.store(flag, depth, best_score, raw_eval, best_move, zobrist_key);
+        tt.store(flag, depth, best_score, raw_eval, best_move, data.get_ply(), zobrist_key);
     }
 
     return best_score;

--- a/search/search_data.hpp
+++ b/search/search_data.hpp
@@ -13,21 +13,6 @@ enum class NodeType : std::uint8_t {
     Root, PV, Non_PV, Null
 };
 
-enum class Bound : std::uint8_t {
-    EXACT, // Type 1 - score is exact
-    LOWER, // Type 2 - score is bigger than beta (fail-high) - Beta node
-    UPPER  // Type 3 - score is lower than alpha (fail-low)  - Alpha node
-};
-
-struct TT_entry {
-    Bound bound;            // 8 bits
-    std::int8_t depth;      // 8 bits
-    std::int16_t score;     // 16 bits
-    std::int16_t static_eval; // 16 bits
-    chess_move tt_move;     // 16 bits
-    std::uint64_t zobrist;  // 64 bits
-};
-
 transposition_table<TT_entry> tt(32 * 1024 * 1024);
 
 struct history_move {

--- a/search/tables/transposition_table.hpp
+++ b/search/tables/transposition_table.hpp
@@ -58,11 +58,11 @@ public:
             if (best_score < -19'000) return static_cast<int16_t>(best_score - ply);
             return best_score;
         }();
-        tt[zobrist_key] = { flag, depth, stored_score, raw_eval, best_move, 0, upper(zobrist_key) };
+        (*this)[zobrist_key] = TT_ENTRY{ flag, depth, stored_score, raw_eval, best_move, 0, upper(zobrist_key) };
     }
 
     TT_ENTRY retrieve(const uint64_t zobrist_key, const int16_t ply) {
-        TT_ENTRY tt_entry = tt[zobrist_key];
+        TT_ENTRY tt_entry = (*this)[zobrist_key];
 
         tt_entry.score = [&] {
             if (tt_entry.score > 19'000) return static_cast<int16_t>(tt_entry.score - ply);

--- a/search/tables/transposition_table.hpp
+++ b/search/tables/transposition_table.hpp
@@ -4,6 +4,22 @@
 #include <vector>
 #include <cstdint>
 
+enum class Bound : std::uint8_t {
+    EXACT, // Type 1 - score is exact
+    LOWER, // Type 2 - score is bigger than beta (fail-high) - Beta node
+    UPPER  // Type 3 - score is lower than alpha (fail-low)  - Alpha node
+};
+
+struct TT_entry {
+    Bound bound;            // 8 bits
+    std::int8_t depth;      // 8 bits
+    std::int16_t score;     // 16 bits
+    std::int16_t static_eval; // 16 bits
+    chess_move tt_move;     // 16 bits
+    std::uint32_t age;      // 32 bits (but can be less, and unused for now)
+    std::uint32_t zobrist;  // 32 bits
+};
+
 template<typename TT_ENTRY>
 class transposition_table {
 public:
@@ -33,6 +49,21 @@ public:
         std::uint64_t index = static_cast<std::uint64_t>((static_cast<__int128>(zobrist_hash) * static_cast<__int128>(bucket_count)) >> 64);
         return tt_table[index];
     }
+
+    void store(const Bound flag, const int8_t depth, const int16_t best_score, const int16_t raw_eval, const chess_move best_move, const uint64_t zobrist_key) {
+        tt[zobrist_key] = { flag, depth, best_score, raw_eval, best_move, 0, upper(zobrist_key) };
+    }
+
+    TT_ENTRY retrieve(const uint64_t zobrist_key) {
+        TT_ENTRY tt_entry;
+        tt_entry = tt[zobrist_key];
+        return tt_entry;
+    }
+
+    uint32_t upper(const uint64_t zobrist_key) const {
+        return (zobrist_key & 0xFFFFFFFF00000000) >> 32;
+    }
+
 private:
     std::vector<TT_ENTRY> tt_table;
     std::uint64_t bucket_count;

--- a/search/tables/transposition_table.hpp
+++ b/search/tables/transposition_table.hpp
@@ -50,13 +50,25 @@ public:
         return tt_table[index];
     }
 
-    void store(const Bound flag, const int8_t depth, const int16_t best_score, const int16_t raw_eval, const chess_move best_move, const uint64_t zobrist_key) {
-        tt[zobrist_key] = { flag, depth, best_score, raw_eval, best_move, 0, upper(zobrist_key) };
+    void store(const Bound flag, const int8_t depth, const int16_t best_score, const int16_t raw_eval, const chess_move best_move,
+        const int16_t ply, const uint64_t zobrist_key) {
+
+        const int16_t stored_score = [&] {
+            if (best_score > 19'000) return static_cast<int16_t>(best_score + ply);
+            if (best_score < -19'000) return static_cast<int16_t>(best_score - ply);
+            return best_score;
+        }();
+        tt[zobrist_key] = { flag, depth, stored_score, raw_eval, best_move, 0, upper(zobrist_key) };
     }
 
-    TT_ENTRY retrieve(const uint64_t zobrist_key) {
-        TT_ENTRY tt_entry;
-        tt_entry = tt[zobrist_key];
+    TT_ENTRY retrieve(const uint64_t zobrist_key, const int16_t ply) {
+        TT_ENTRY tt_entry = tt[zobrist_key];
+
+        tt_entry.score = [&] {
+            if (tt_entry.score > 19'000) return static_cast<int16_t>(tt_entry.score - ply);
+            if (tt_entry.score < -19'000) return static_cast<int16_t>(tt_entry.score + ply);
+            return tt_entry.score;
+        }();
         return tt_entry;
     }
 


### PR DESCRIPTION
This PR makes the following changes:
- adds new functions for storing and retrieving TT entries
- enables TT cutoffs for mate values
- adjusts TT mate values based on plies to be accurate
- frees up 32 bits in the TT entry to be used later for something else (e.g. ageing)
- changes to fail-hard in NMP if the returned score is a mate value

Earlier version passed gainer bounds for endgames.epd with adjudication turned off:
```
Elo   | 13.69 +- 5.46 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2108 W: 353 L: 270 D: 1485
Penta | [0, 103, 766, 184, 1]
https://zzzzz151.pythonanywhere.com/test/334/
```

Passed non-regression under regular testing procedures:
```
Elo   | -0.40 +- 1.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 41784 W: 9904 L: 9952 D: 21928
Penta | [158, 4708, 11198, 4680, 148]
https://zzzzz151.pythonanywhere.com/test/340/
```

Bench: 3087460