### PR TITLE
lmr depth move score

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -193,7 +193,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
                         continue;
                     }
 
-                    int lmr_depth = std::max(0, depth - reduction);
+                    int lmr_depth = std::max(0, depth - reduction + movelist.get_move_score(moves_searched) / 6000);
                     if (lmr_depth < fp_depth && static_eval + fp_base + fp_mul * lmr_depth <= alpha) {
                         continue;
                     }


### PR DESCRIPTION
Elo   | 4.45 +- 3.25 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11632 W: 2853 L: 2704 D: 6075
Penta | [40, 1308, 2972, 1455, 41]

Bench: 3436807