### PR TITLE
Remove counter move heuristic

### DIFF
--- a/search/move_ordering/move_ordering.hpp
+++ b/search/move_ordering/move_ordering.hpp
@@ -27,8 +27,6 @@ void score_moves(board & chessboard, move_list & movelist, search_data & data, c
     for (chess_move & move : movelist) {
         const Square from = move.get_from();
         const Square to   = move.get_to();
-        const chess_move previous_move = chessboard.get_last_played_move();
-        const chess_move counter_move = data.counter_moves[previous_move.get_from()][previous_move.get_to()];
         int move_score;
         if (move == tt_move) {
             move_score = 214748364;

--- a/search/move_ordering/move_ordering.hpp
+++ b/search/move_ordering/move_ordering.hpp
@@ -37,8 +37,6 @@ void score_moves(board & chessboard, move_list & movelist, search_data & data, c
             move_score += capture_table[chessboard.get_piece(from)][to][chessboard.get_piece(to)];
         } else if (data.get_killer() == move){
             move_score = 1'000'002;
-        } else if (move == counter_move) {
-            move_score = 1'000'000;
         } else {
             move_score = get_history<color>(chessboard, data, from, to, chessboard.get_piece(from));
         }

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -172,7 +172,6 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
     std::int16_t best_score = -INF;
     score_moves<color>(chessboard, movelist, data, best_move);
-    const chess_move previous_move = chessboard.get_last_played_move();
 
     for (std::uint8_t moves_searched = 0; moves_searched < movelist.size(); moves_searched++) {
         chess_move& chessmove = movelist.get_next_move(moves_searched);
@@ -296,10 +295,8 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
                 if (alpha >= beta) {
                     flag = Bound::LOWER;
-                    int bonus = history_bonus(depth);
                     if (is_quiet) {
                         data.update_killer(chessmove);
-                        data.counter_moves[previous_move.get_from()][previous_move.get_to()] = chessmove;
                     }
                     update_history<color, is_root>(data, chessboard, best_move, quiets, captures, depth);
                     break;

--- a/search/search_data.hpp
+++ b/search/search_data.hpp
@@ -38,7 +38,6 @@ public:
     }
 
     bool time_is_up(int depth) {
-        //timekeeper.can_end(nodes(), principal_variation_table.get_best_move());
         return timekeeper.can_end(nodes(), principal_variation_table.get_best_move(), depth);
     }
 
@@ -115,9 +114,7 @@ public:
     int improving[96] = {};
 
     history_move prev_moves[96];
-    
 
-    chess_move counter_moves[64][64] = {};
     std::uint32_t singular_move = {};
     int stack_eval = {};
     int double_extension[96] = {};


### PR DESCRIPTION
Elo   | 3.05 +- 2.16 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 27838 W: 6744 L: 6500 D: 14594
Penta | [103, 3310, 6902, 3448, 156]

Bench: 3198318