### PR TITLE
Prune bad moves in check in qs

### DIFF
--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -32,9 +32,11 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
 
     std::uint64_t zobrist_key = chessboard.get_hash_key();
     const TT_entry& tt_entry = tt.retrieve(zobrist_key, data.get_ply());
+    chess_move tt_move = {};
 
     if (tt_entry.zobrist == tt.upper(zobrist_key)) {
         std::int16_t tt_eval = tt_entry.score;
+        tt_move = tt_entry.tt_move;
         static_eval = tt_entry.static_eval;
         eval = tt_eval;
         if ((tt_entry.bound == Bound::EXACT) ||
@@ -57,19 +59,23 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
     move_list movelist;
     if (in_check) {
         generate_all_moves<color, false>(chessboard, movelist);
+        score_moves<color>(chessboard, movelist, data, tt_move);
         if (movelist.size() == 0) {
             return data.mate_value();
         }
     } else {
         generate_all_moves<color, true>(chessboard, movelist);
+        qs_score_moves(chessboard, movelist);
     }
-
-    qs_score_moves(chessboard, movelist);
 
     chess_move best_move;
 
     for (std::uint8_t moves_searched = 0; moves_searched < movelist.size(); moves_searched++) {
         chess_move & chessmove = movelist.get_next_move(moves_searched);
+
+        if (in_check && movelist.get_move_score(moves_searched) < 16'000 && moves_searched) {
+            break;
+        }
 
         if (!in_check && !see<color>(chessboard, chessmove)) {
             continue;


### PR DESCRIPTION
Elo   | 4.09 +- 2.58 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 18608 W: 4483 L: 4264 D: 9861
Penta | [60, 2129, 4719, 2324, 72]

Bench: 3096066