### PR TITLE
No depth condition in SEE pruning

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -242,7 +242,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
 
                 int see_margin = is_quiet ? -see_quiet * depth : -see_noisy * depth * depth;
-                if (depth < see_depth && !see<color>(chessboard, chessmove, see_margin)) {
+                if (!see<color>(chessboard, chessmove, see_margin)) {
                     continue;
                 }
             }


### PR DESCRIPTION
Elo   | 2.41 +- 1.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 37456 W: 8893 L: 8633 D: 19930
Penta | [124, 4347, 9535, 4589, 133]

Bench: 3053409