### PR TITLE
Material correction history

### DIFF
--- a/chess_board/board.hpp
+++ b/chess_board/board.hpp
@@ -437,6 +437,7 @@ public:
         return (current_index + 1) / 2;
     }
 
+    template <Color side>
     std::uint64_t get_material_key() const {
         auto murmur_hash_3 = [](std::uint64_t key) -> std::uint64_t {
             key ^= key >> 33;
@@ -448,12 +449,12 @@ public:
         };
 
         std::uint64_t material_key = 0;
-        std::uint64_t piece_positions[5] = {0, 6, 12, 18, 24}; // Pawn, Knight, Bishop, Rook, Queen
 
         for (Color c : {Color::White, Color::Black}) {
             for (Piece p : {Pawn, Knight, Bishop, Rook, Queen}) {
+                int shift = p * 6 + (c != side) * 30;
                 std::uint64_t count = std::popcount(bitboards[c][p]);
-                material_key |= (count << (p * 6 + c * 30));
+                material_key |= (count << shift);
             }
         }
 

--- a/chess_board/board.hpp
+++ b/chess_board/board.hpp
@@ -437,7 +437,6 @@ public:
         return (current_index + 1) / 2;
     }
 
-    template <Color side>
     std::uint64_t get_material_key() const {
         auto murmur_hash_3 = [](std::uint64_t key) -> std::uint64_t {
             key ^= key >> 33;
@@ -452,8 +451,8 @@ public:
 
         for (Color c : {Color::White, Color::Black}) {
             for (Piece p : {Pawn, Knight, Bishop, Rook, Queen}) {
-                int shift = p * 6 + (c != side) * 30;
-                std::uint64_t count = std::popcount(bitboards[c][p]);
+                int shift = p * 6 + c * 30;
+                std::uint64_t count = std::popcount(this->bitboards[c][p]);
                 material_key |= (count << shift);
             }
         }

--- a/chess_board/board.hpp
+++ b/chess_board/board.hpp
@@ -451,12 +451,9 @@ public:
         std::uint64_t piece_positions[5] = {0, 6, 12, 18, 24}; // Pawn, Knight, Bishop, Rook, Queen
 
         for (Color c : {Color::White, Color::Black}) {
-            int color_index = (c == Color::White) ? 0 : 1;
-            std::uint64_t shift = (c == Color::White) ? 0 : 30;
-
-            for (size_t i = 0; i < 5; ++i) {
-                std::uint64_t count = std::popcount(bitboards[color_index][i]);
-                material_key |= (count << (piece_positions[i] + shift));
+            for (Piece p : {Pawn, Knight, Bishop, Rook, Queen}) {
+                std::uint64_t count = std::popcount(bitboards[c][p]);
+                material_key |= (count << (p * 6 + c * 30));
             }
         }
 

--- a/chess_board/board.hpp
+++ b/chess_board/board.hpp
@@ -436,6 +436,32 @@ public:
         const int current_index = state - history.data();
         return (current_index + 1) / 2;
     }
+
+    std::uint64_t get_material_key() const {
+        auto murmur_hash_3 = [](std::uint64_t key) -> std::uint64_t {
+            key ^= key >> 33;
+            key *= 0xff51afd7ed558ccd;
+            key ^= key >> 33;
+            key *= 0xc4ceb9fe1a85ec53;
+            key ^= key >> 33;
+            return key;
+        };
+
+        std::uint64_t material_key = 0;
+        std::uint64_t piece_positions[5] = {0, 6, 12, 18, 24}; // Pawn, Knight, Bishop, Rook, Queen
+
+        for (Color c : {Color::White, Color::Black}) {
+            int color_index = (c == Color::White) ? 0 : 1;
+            std::uint64_t shift = (c == Color::White) ? 0 : 30;
+
+            for (size_t i = 0; i < 5; ++i) {
+                std::uint64_t count = std::popcount(bitboards[color_index][i]);
+                material_key |= (count << (piece_positions[i] + shift));
+            }
+        }
+
+        return murmur_hash_3(material_key);
+    }
 };
 
 #endif //MOTOR_BOARD_HPP

--- a/cli/uci.hpp
+++ b/cli/uci.hpp
@@ -135,6 +135,7 @@ void uci_process(board& b, const std::string& line) {
         continuation_table = {};
         capture_table = {};
         correction_table = {};
+        material_correction_table = {};
         tt.clear();
     } else if (command == "setoption") {
         std::string token;
@@ -156,6 +157,7 @@ void uci_process(board& b, const std::string& line) {
         continuation_table = {};
         capture_table = {};
         correction_table = {};
+        material_correction_table = {};
         tt.clear();
         bench(13);
     } else if (command == "perft") {

--- a/cli/uci.hpp
+++ b/cli/uci.hpp
@@ -135,7 +135,6 @@ void uci_process(board& b, const std::string& line) {
         continuation_table = {};
         capture_table = {};
         correction_table = {};
-        material_correction_table = {};
         tt.clear();
     } else if (command == "setoption") {
         std::string token;
@@ -157,7 +156,6 @@ void uci_process(board& b, const std::string& line) {
         continuation_table = {};
         capture_table = {};
         correction_table = {};
-        material_correction_table = {};
         tt.clear();
         bench(13);
     } else if (command == "perft") {

--- a/evaluation/nnue.hpp
+++ b/evaluation/nnue.hpp
@@ -43,6 +43,12 @@ int screlu(int x) {
 }
 
 template<std::uint16_t hidden_size>
+struct accumulator_cache {
+    std::array<std::array<std::int16_t, hidden_size>, 128> white_accumulator_stack;
+    std::array<std::array<std::int16_t, hidden_size>, 128> black_accumulator_stack;
+};
+
+template<std::uint16_t hidden_size>
 class perspective_network
 {
 public:

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -47,7 +47,7 @@ template <Color color>
 std::int16_t correct_eval(const board & chessboard, search_data& data, int raw_eval) {
     if (std::abs(raw_eval) > 8'000) return raw_eval;
     const int entry = correction_table[color][chessboard.get_pawn_key() % 16384];
-    const int material_entry = material_correction_table[color][chessboard.get_pawn_key() % 65536];
+    const int material_entry = material_correction_table[color][chessboard.get_material_key() % 65536];
     return raw_eval + entry / 256 + material_entry / 256;
 }
 
@@ -368,15 +368,13 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
             int weight = flag == Bound::EXACT ? std::min(4 * depth * depth + 8 * depth + 4, 512)
                                               : std::min(3 * depth * depth + 6 * depth + 3, 384);
 
-            int material_weight = std::min(depth + 1, 16);
-
             int & entry = correction_table[color][chessboard.get_pawn_key() % 16384];
             entry = (entry * (4096 - weight) + diff * weight) / 4096;
             entry = std::clamp(entry, -16'384, 16'384);
 
             int & material_entry = material_correction_table[color][chessboard.get_material_key() % 65536];
-            material_entry = (material_entry * (256 - material_weight) + diff * material_weight) / 256;
-            material_entry = std::clamp(material_entry, -8192, 8192);
+            material_entry = (material_entry * (4096 - weight) + diff * weight) / 4096;
+            material_entry = std::clamp(material_entry, -16'384, 16'384);
         }
 
         if (!would_tt_prune) {

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -47,7 +47,7 @@ template <Color color>
 std::int16_t correct_eval(const board & chessboard, search_data& data, int raw_eval) {
     if (std::abs(raw_eval) > 8'000) return raw_eval;
     const int entry = correction_table[color][chessboard.get_pawn_key() % 16384];
-    const int material_entry = material_correction_table[color][chessboard.get_material_key<color>() % 32768];
+    const int material_entry = material_correction_table[color][chessboard.get_material_key() % 65536];
     return raw_eval + entry / 256 + material_entry / 256;
 }
 
@@ -370,11 +370,11 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
             int & entry = correction_table[color][chessboard.get_pawn_key() % 16384];
             entry = (entry * (4096 - weight) + diff * weight) / 4096;
-            entry = std::clamp(entry, -16'384, 16'384);
+            entry = std::clamp(entry, -12'288, 12'288);
 
-            int & material_entry = material_correction_table[color][chessboard.get_material_key<color>() % 32768];
+            int & material_entry = material_correction_table[color][chessboard.get_material_key() % 65536];
             material_entry = (material_entry * (4096 - weight) + diff * weight) / 4096;
-            material_entry = std::clamp(material_entry, -8192, 8192);
+            material_entry = std::clamp(material_entry, -12'288, 12'288);
         }
 
         if (!would_tt_prune) {

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -47,7 +47,7 @@ template <Color color>
 std::int16_t correct_eval(const board & chessboard, search_data& data, int raw_eval) {
     if (std::abs(raw_eval) > 8'000) return raw_eval;
     const int entry = correction_table[color][chessboard.get_pawn_key() % 16384];
-    const int material_entry = material_correction_table[color][chessboard.get_material_key() % 65536];
+    const int material_entry = material_correction_table[color][chessboard.get_material_key<color>() % 32768];
     return raw_eval + entry / 256 + material_entry / 256;
 }
 
@@ -372,9 +372,9 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
             entry = (entry * (4096 - weight) + diff * weight) / 4096;
             entry = std::clamp(entry, -16'384, 16'384);
 
-            int & material_entry = material_correction_table[color][chessboard.get_material_key() % 65536];
+            int & material_entry = material_correction_table[color][chessboard.get_material_key<color>() % 32768];
             material_entry = (material_entry * (4096 - weight) + diff * weight) / 4096;
-            material_entry = std::clamp(material_entry, -16'384, 16'384);
+            material_entry = std::clamp(material_entry, -8192, 8192);
         }
 
         if (!would_tt_prune) {

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -44,10 +44,11 @@ constexpr int asp_window_max = 666;
 constexpr int asp_depth = 8;
 
 template <Color color>
-std::int16_t correct_eval(const board & chessboard, search_data& data, int raw_eval, int krisz_key) {
+std::int16_t correct_eval(const board & chessboard, search_data& data, int raw_eval) {
     if (std::abs(raw_eval) > 8'000) return raw_eval;
-    const int entry = correction_table[color][krisz_key];
-    return raw_eval + entry / 256;
+    const int entry = correction_table[color][chessboard.get_pawn_key() % 16384];
+    const int material_entry = material_correction_table[color][chessboard.get_material_key() % 32768];
+    return raw_eval + (entry + material_entry) / 256;
 }
 
 template <Color color, NodeType node_type>
@@ -88,14 +89,13 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
     chess_move tt_move = {};
     std::int16_t eval, static_eval, raw_eval;
     bool would_tt_prune = false;
-    const int krisz_key = (chessboard.get_pawn_key() ^ chessboard.get_material_key()) % 16384;
 
     if (data.singular_move == 0 && tt_entry.zobrist == tt.upper(zobrist_key)) {
         best_move = tt_entry.tt_move;
         tt_move = tt_entry.tt_move;
         std::int16_t tt_eval = tt_entry.score;
         raw_eval = tt_entry.static_eval;
-        eval = static_eval = correct_eval<color>(chessboard, data, raw_eval, krisz_key);
+        eval = static_eval = correct_eval<color>(chessboard, data, raw_eval);
 
         if constexpr (!is_root) {
             if (tt_entry.depth >= depth + 2 * is_pv) {
@@ -121,7 +121,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
         }
     } else {
         raw_eval = in_check ? -INF : evaluate<color>(chessboard);
-        eval = static_eval = correct_eval<color>(chessboard, data, raw_eval, krisz_key);
+        eval = static_eval = correct_eval<color>(chessboard, data, raw_eval);
         if (data.singular_move == 0 && depth >= iir_depth) {
             depth--;
         }
@@ -362,14 +362,18 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
     if (data.singular_move == 0) {
         if (!(in_check || !chessboard.is_quiet(best_move)
-            || (flag == Bound::LOWER && best_score <= static_eval) || (flag == Bound::UPPER && best_score >= static_eval))
-        ) {
+              || (flag == Bound::LOWER && best_score <= static_eval) || (flag == Bound::UPPER && best_score >= static_eval))
+                ) {
             int diff = (best_score - raw_eval) * 256;
             int weight = std::min(16, depth + 1);
 
-            int & entry = correction_table[color][krisz_key];
+            int & entry = correction_table[color][chessboard.get_pawn_key() % 16384];
             entry = (entry * (256 - weight) + diff * weight) / 256;
-            entry = std::clamp(entry, -16'384, 16'384);
+            entry = std::clamp(entry, -8'192, 8'192);
+
+            int & material_entry = material_correction_table[color][chessboard.get_material_key() % 32768];
+            material_entry = (material_entry * (256 - weight) + diff * weight) / 256;
+            material_entry = std::clamp(material_entry, -8'192, 8'192);
         }
 
         if (!would_tt_prune) {

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -47,8 +47,8 @@ template <Color color>
 std::int16_t correct_eval(const board & chessboard, search_data& data, int raw_eval) {
     if (std::abs(raw_eval) > 8'000) return raw_eval;
     const int entry = correction_table[color][chessboard.get_pawn_key() % 16384];
-    const int material_entry = material_correction_table[color][chessboard.get_material_key() % 65536];
-    return raw_eval + entry / 256 + material_entry / 256;
+    const int material_entry = material_correction_table[color][chessboard.get_material_key() % 16384];
+    return raw_eval + (entry + material_entry) / 256;
 }
 
 template <Color color, NodeType node_type>
@@ -370,11 +370,11 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
             int & entry = correction_table[color][chessboard.get_pawn_key() % 16384];
             entry = (entry * (4096 - weight) + diff * weight) / 4096;
-            entry = std::clamp(entry, -12'288, 12'288);
+            entry = std::clamp(entry, -16'384, 16'384);
 
-            int & material_entry = material_correction_table[color][chessboard.get_material_key() % 65536];
-            material_entry = (material_entry * (4096 - weight) + diff * weight) / 4096;
-            material_entry = std::clamp(material_entry, -12'288, 12'288);
+            int & material_entry = material_correction_table[color][chessboard.get_material_key() % 16384];
+            material_entry = (material_entry * 255 + diff) / 256;
+            material_entry = std::clamp(material_entry, -16'384, 16'384);
         }
 
         if (!would_tt_prune) {

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -11,6 +11,7 @@ std::array<std::array<std::array<std::array<std::array<int, 64>, 64>, 2>, 2>, 2>
 std::array<std::array<std::array<std::array<int, 64>, 6>, 64>, 6> continuation_table = {};
 std::array<std::array<std::array<int, 7>, 64>, 6> capture_table = {};
 std::array<std::array<int, 16384>, 2> correction_table = {};
+std::array<std::array<int, 65536>, 2> material_correction_table = {};
 
 constexpr int noisy_mul = 41;
 constexpr int noisy_max = 375;

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -11,7 +11,7 @@ std::array<std::array<std::array<std::array<std::array<int, 64>, 64>, 2>, 2>, 2>
 std::array<std::array<std::array<std::array<int, 64>, 6>, 64>, 6> continuation_table = {};
 std::array<std::array<std::array<int, 7>, 64>, 6> capture_table = {};
 std::array<std::array<int, 16384>, 2> correction_table = {};
-std::array<std::array<int, 65536>, 2> material_correction_table = {};
+std::array<std::array<int, 16384>, 2> material_correction_table = {};
 
 constexpr int noisy_mul = 41;
 constexpr int noisy_max = 375;

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -11,6 +11,7 @@ std::array<std::array<std::array<std::array<std::array<int, 64>, 64>, 2>, 2>, 2>
 std::array<std::array<std::array<std::array<int, 64>, 6>, 64>, 6> continuation_table = {};
 std::array<std::array<std::array<int, 7>, 64>, 6> capture_table = {};
 std::array<std::array<int, 16384>, 2> correction_table = {};
+std::array<std::array<int, 32768>, 2> material_correction_table = {};
 
 constexpr int noisy_mul = 41;
 constexpr int noisy_max = 375;

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -11,7 +11,7 @@ std::array<std::array<std::array<std::array<std::array<int, 64>, 64>, 2>, 2>, 2>
 std::array<std::array<std::array<std::array<int, 64>, 6>, 64>, 6> continuation_table = {};
 std::array<std::array<std::array<int, 7>, 64>, 6> capture_table = {};
 std::array<std::array<int, 16384>, 2> correction_table = {};
-std::array<std::array<int, 16384>, 2> material_correction_table = {};
+std::array<std::array<int, 32768>, 2> material_correction_table = {};
 
 constexpr int noisy_mul = 41;
 constexpr int noisy_max = 375;

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -11,7 +11,6 @@ std::array<std::array<std::array<std::array<std::array<int, 64>, 64>, 2>, 2>, 2>
 std::array<std::array<std::array<std::array<int, 64>, 6>, 64>, 6> continuation_table = {};
 std::array<std::array<std::array<int, 7>, 64>, 6> capture_table = {};
 std::array<std::array<int, 16384>, 2> correction_table = {};
-std::array<std::array<int, 32768>, 2> material_correction_table = {};
 
 constexpr int noisy_mul = 41;
 constexpr int noisy_max = 375;

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -11,7 +11,7 @@ std::array<std::array<std::array<std::array<std::array<int, 64>, 64>, 2>, 2>, 2>
 std::array<std::array<std::array<std::array<int, 64>, 6>, 64>, 6> continuation_table = {};
 std::array<std::array<std::array<int, 7>, 64>, 6> capture_table = {};
 std::array<std::array<int, 16384>, 2> correction_table = {};
-std::array<std::array<int, 32768>, 2> material_correction_table = {};
+std::array<std::array<int, 65536>, 2> material_correction_table = {};
 
 constexpr int noisy_mul = 41;
 constexpr int noisy_max = 375;

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -11,7 +11,7 @@ std::array<std::array<std::array<std::array<std::array<int, 64>, 64>, 2>, 2>, 2>
 std::array<std::array<std::array<std::array<int, 64>, 6>, 64>, 6> continuation_table = {};
 std::array<std::array<std::array<int, 7>, 64>, 6> capture_table = {};
 std::array<std::array<int, 16384>, 2> correction_table = {};
-std::array<std::array<int, 65536>, 2> material_correction_table = {};
+std::array<std::array<int, 32768>, 2> material_correction_table = {};
 
 constexpr int noisy_mul = 41;
 constexpr int noisy_max = 375;


### PR DESCRIPTION
Idea from Caissa. Correct static evaluation based on material counts.

```
Elo   | 3.36 +- 2.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 24000 W: 5836 L: 5604 D: 12560
Penta | [75, 2829, 5972, 3037, 87]
```

Bench: 2608021