### PR TITLE
Remove check extensions completely

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -249,7 +249,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
             }
         }
 
-        int ext = in_check;
+        int ext = 0;
 
         if constexpr (!is_root) {
             if (depth >= se_depth &&


### PR DESCRIPTION
Elo   | 4.09 +- 3.50 (95%)
SPRT  | 14.0+0.14s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 9858 W: 2298 L: 2182 D: 5378
Penta | [21, 1140, 2490, 1258, 20]

Bench: 1814424