### PR TITLE
Nonpawn structure correction table

### DIFF
--- a/cli/uci.hpp
+++ b/cli/uci.hpp
@@ -135,6 +135,7 @@ void uci_process(board& b, const std::string& line) {
         continuation_table = {};
         capture_table = {};
         correction_table = {};
+        nonpawn_correction_table = {};
         material_correction_table = {};
         tt.clear();
     } else if (command == "setoption") {
@@ -157,6 +158,7 @@ void uci_process(board& b, const std::string& line) {
         continuation_table = {};
         capture_table = {};
         correction_table = {};
+        nonpawn_correction_table = {};
         material_correction_table = {};
         tt.clear();
         bench(13);

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -11,6 +11,7 @@ std::array<std::array<std::array<std::array<std::array<int, 64>, 64>, 2>, 2>, 2>
 std::array<std::array<std::array<std::array<int, 64>, 6>, 64>, 6> continuation_table = {};
 std::array<std::array<std::array<int, 7>, 64>, 6> capture_table = {};
 std::array<std::array<int, 16384>, 2> correction_table = {};
+std::array<std::array<std::array<int, 16384>, 2>, 2> nonpawn_correction_table = {};
 std::array<std::array<int, 32768>, 2> material_correction_table = {};
 
 constexpr int noisy_mul = 41;


### PR DESCRIPTION
Idea from Starzix. Correct static evaluation based on nonpawn structure

Elo   | 3.30 +- 2.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 3.00]
Games | N: 24942 W: 6088 L: 5851 D: 13003
Penta | [92, 2911, 6235, 3134, 99]

Bench: 1960865