### PR TITLE
Futility pruning improving

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -237,7 +237,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
                         continue;
                     }
 
-                    int lmr_depth = std::max(0, depth - reduction + movelist.get_move_score(moves_searched) / 6000);
+                    int lmr_depth = std::max(0, depth - reduction - !improving + movelist.get_move_score(moves_searched) / 6000);
                     if (lmr_depth < fp_depth && static_eval + fp_base + fp_mul * lmr_depth <= alpha) {
                         continue;
                     }


### PR DESCRIPTION
Prune more when position is not improving

Elo   | 7.80 +- 3.78 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 8950 W: 2218 L: 2017 D: 4715
Penta | [24, 1026, 2191, 1193, 41]

Bench: 3176410