### PR TITLE
Add material structure history into move ordering

### DIFF
--- a/cli/uci.hpp
+++ b/cli/uci.hpp
@@ -137,6 +137,7 @@ void uci_process(board& b, const std::string& line) {
         correction_table = {};
         nonpawn_correction_table = {};
         material_correction_table = {};
+        material_history_table = {};
         tt.clear();
     } else if (command == "setoption") {
         std::string token;
@@ -160,6 +161,7 @@ void uci_process(board& b, const std::string& line) {
         correction_table = {};
         nonpawn_correction_table = {};
         material_correction_table = {};
+        material_history_table = {};
         tt.clear();
         bench(13);
     } else if (command == "perft") {

--- a/search/move_ordering/move_ordering.hpp
+++ b/search/move_ordering/move_ordering.hpp
@@ -22,7 +22,7 @@ constexpr int noisy_base = -409;
 constexpr int mvv[7] = { 147, 441, 312, 1039, 1232, 0, 1044 };
 
 template <Color color>
-void score_moves(board & chessboard, move_list & movelist, search_data & data, const chess_move & tt_move) {
+void score_moves(board & chessboard, move_list & movelist, search_data & data, const chess_move & tt_move, int material_key) {
     int move_index = 0;
     for (chess_move & move : movelist) {
         const Square from = move.get_from();
@@ -36,7 +36,7 @@ void score_moves(board & chessboard, move_list & movelist, search_data & data, c
         } else if (data.get_killer() == move){
             move_score = 1'000'002;
         } else {
-            move_score = get_history<color>(chessboard, data, from, to, chessboard.get_piece(from));
+            move_score = get_history<color>(chessboard, data, from, to, chessboard.get_piece(from), material_key);
         }
         
         movelist[move_index] = move_score;

--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -59,7 +59,7 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
     move_list movelist;
     if (in_check) {
         generate_all_moves<color, false>(chessboard, movelist);
-        score_moves<color>(chessboard, movelist, data, tt_move);
+        score_moves<color>(chessboard, movelist, data, tt_move, chessboard.get_material_key() % 512);
         if (movelist.size() == 0) {
             return data.mate_value();
         }

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -8,6 +8,7 @@
 #include "../search_data.hpp"
 
 std::array<std::array<std::array<std::array<std::array<int, 64>, 64>, 2>, 2>, 2> history_table = {};
+std::array<std::array<std::array<std::array<int, 64>, 6>, 2>, 512> material_history_table = {};
 std::array<std::array<std::array<std::array<int, 64>, 6>, 64>, 6> continuation_table = {};
 std::array<std::array<std::array<int, 7>, 64>, 6> capture_table = {};
 std::array<std::array<int, 16384>, 2> correction_table = {};
@@ -33,7 +34,7 @@ void update_cap_history(int& value, int bonus) {
 }
 
 template <Color color, bool is_root>
-void update_history(search_data & data, board & chessboard, const chess_move & best_move, move_list & quiets, move_list & captures, int depth) {
+void update_history(search_data & data, board & chessboard, const chess_move & best_move, move_list & quiets, move_list & captures, int depth, int material_key) {
     int bonus = history_bonus(depth);
     int cap_bonus = std::min(noisy_max, noisy_mul * depth);
 
@@ -46,6 +47,7 @@ void update_history(search_data & data, board & chessboard, const chess_move & b
         bool threat_from = (threats & bb(from));
         bool threat_to = (threats & bb(to));
         update_history(history_table[color][threat_from][threat_to][from][to], bonus);
+        update_history(material_history_table[material_key][color][piece][to], bonus);
 
         if constexpr (!is_root) {
             prev = data.prev_moves[data.get_ply() - 1];
@@ -68,6 +70,7 @@ void update_history(search_data & data, board & chessboard, const chess_move & b
             bool qthreat_from = (threats & bb(qfrom));
             bool qthreat_to = (threats & bb(qto));
             update_history(history_table[color][qthreat_from][qthreat_to][qfrom][qto], malus);
+            update_history(material_history_table[material_key][color][qpiece][qto], malus);
 
             if constexpr (!is_root) {
                 update_history(continuation_table[prev.piece_type][prev.to][qpiece][qto], malus);
@@ -91,12 +94,13 @@ void update_history(search_data & data, board & chessboard, const chess_move & b
 }
 
 template <Color color>
-int get_history(board & chessboard, search_data & data, Square from, Square to, Piece piece) {
+int get_history(board & chessboard, search_data & data, Square from, Square to, Piece piece, int material_key) {
     std::uint64_t threats = chessboard.get_threats();
     bool threat_from = (threats & bb(from));
     bool threat_to = (threats & bb(to));
 
     int move_score = history_table[color][threat_from][threat_to][from][to];
+    move_score += material_history_table[material_key][color][piece][to];
     if (data.get_ply()) {
         auto prev = data.prev_moves[data.get_ply() - 1];
         move_score += continuation_table[prev.piece_type][prev.to][piece][to];


### PR DESCRIPTION
Elo   | 2.22 +- 1.71 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 43042 W: 10600 L: 10325 D: 22117
Penta | [132, 5145, 10738, 5328, 178]

Bench: 4822216