### PR TITLE
corrhist fix

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -367,7 +367,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
     }
 
     if (data.singular_move == 0) {
-        if (!(in_check || !chessboard.is_quiet(best_move)
+        if (!(in_check || !(best_move.get_value() == 0 || chessboard.is_quiet(best_move))
               || (flag == Bound::LOWER && best_score <= static_eval) || (flag == Bound::UPPER && best_score >= static_eval))
         ) {
             int diff = (best_score - raw_eval) * 256;


### PR DESCRIPTION
Elo   | 1.56 +- 3.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 3.02 (-2.94, 2.94) [-5.00, 0.00]
Games | N: 13104 W: 3116 L: 3057 D: 6931
Penta | [30, 1555, 3332, 1596, 39]

Bench: 3959159