### PR TITLE
Use pawn structure static evaluation correction history in qs

### DIFF
--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -10,6 +10,13 @@
 #include "../executioner/makemove.hpp"
 
 template <Color color>
+std::int16_t correct_eval(const board & chessboard, int raw_eval) {
+    if (std::abs(raw_eval) > 8'000) return raw_eval;
+    const int entry = correction_table[color][chessboard.get_pawn_key() % 16384];
+    return raw_eval + entry / 256;
+}
+
+template <Color color>
 std::int16_t quiescence_search(board & chessboard, search_data & data, std::int16_t alpha, std::int16_t beta, std::int8_t depth = 0) {
     constexpr Color enemy_color = (color == White) ? Black : White;
 
@@ -46,6 +53,7 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
         }
     } else {
         static_eval = eval = in_check ? -INF : evaluate<color>(chessboard);
+        eval = correct_eval<color>(chessboard, static_eval);
     }
 
     if (eval >= beta) {


### PR DESCRIPTION
``` 
Elo   | 3.00 +- 2.13 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 27080 W: 6485 L: 6251 D: 14344
Penta | [103, 3057, 6979, 3305, 96]
```

Bench: 4042819