### PR TITLE
Big correction weights

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -373,7 +373,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
               || (flag == Bound::LOWER && best_score <= static_eval) || (flag == Bound::UPPER && best_score >= static_eval))
         ) {
             int diff = (best_score - raw_eval) * 256;
-            int weight = std::min(16, depth + 1);
+            int weight = std::min(128, depth * (depth + 1));
 
             int & entry = correction_table[color][chessboard.get_pawn_key() % 16384];
             entry = (entry * (256 - weight) + diff * weight) / 256;


### PR DESCRIPTION
Elo   | 3.23 +- 2.24 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 24208 W: 5805 L: 5580 D: 12823
Penta | [68, 2785, 6174, 3008, 69]

Bench: 4402854