### PR TITLE
Simplify caphist

### DIFF
--- a/search/move_ordering/move_ordering.hpp
+++ b/search/move_ordering/move_ordering.hpp
@@ -19,7 +19,7 @@ constexpr static int mvv_lva[7][6] = {
 
 constexpr int noisy_base = -409;
 
-constexpr int mvv[7] = { 147, 441, 312, 1039, 1232, 0, 1044 };
+constexpr int mvv[7] = { 500, 1000, 1000, 2000, 3000, 0, 1044 };
 
 template <Color color>
 void score_moves(board & chessboard, move_list & movelist, search_data & data, const chess_move & tt_move, int material_key) {

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -16,9 +16,9 @@ std::array<std::array<std::array<int, 16384>, 2>, 2> nonpawn_correction_table = 
 std::array<std::array<int, 32768>, 2> material_correction_table = {};
 std::array<std::array<int, 32768>, 2> threat_correction_table = {};
 
-constexpr int noisy_mul = 41;
-constexpr int noisy_max = 375;
-constexpr int noisy_gravity = 1779;
+constexpr int noisy_mul = 236;
+constexpr int noisy_max = 2040;
+constexpr int noisy_gravity = 16384;
 constexpr int quiet_mul = 236;
 constexpr int quiet_max = 2040;
 

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -37,7 +37,7 @@ void update_cap_history(int& value, int bonus) {
 template <Color color, bool is_root>
 void update_history(search_data & data, board & chessboard, const chess_move & best_move, move_list & quiets, move_list & captures, int depth, int material_key) {
     int bonus = history_bonus(depth);
-    int cap_bonus = std::min(noisy_max, noisy_mul * depth);
+    int penalty = -bonus;
 
     auto [piece, from, to] = data.prev_moves[data.get_ply()];
     history_move prev = {}, prev2 = {}, prev4 = {};
@@ -64,33 +64,31 @@ void update_history(search_data & data, board & chessboard, const chess_move & b
         }
 
         for (const auto &quiet: quiets) {
-            int malus = -bonus;
             auto qfrom = quiet.get_from();
             auto qto = quiet.get_to();
             auto qpiece = chessboard.get_piece(qfrom);
             bool qthreat_from = (threats & bb(qfrom));
             bool qthreat_to = (threats & bb(qto));
-            update_history(history_table[color][qthreat_from][qthreat_to][qfrom][qto], malus);
-            update_history(material_history_table[material_key][color][qpiece][qto], malus);
+            update_history(history_table[color][qthreat_from][qthreat_to][qfrom][qto], penalty);
+            update_history(material_history_table[material_key][color][qpiece][qto], penalty);
 
             if constexpr (!is_root) {
-                update_history(continuation_table[prev.piece_type][prev.to][qpiece][qto], malus);
+                update_history(continuation_table[prev.piece_type][prev.to][qpiece][qto], penalty);
                 if (data.get_ply() > 1) {
-                    update_history(continuation_table[prev2.piece_type][prev2.to][qpiece][qto], malus);
+                    update_history(continuation_table[prev2.piece_type][prev2.to][qpiece][qto], penalty);
                     if (data.get_ply() > 3) {
-                        update_history(continuation_table[prev4.piece_type][prev4.to][qpiece][qto], malus);
+                        update_history(continuation_table[prev4.piece_type][prev4.to][qpiece][qto], penalty);
                     }
                 }
             }
         }
     } else {
-        update_cap_history(capture_table[piece][to][chessboard.get_piece(to)], cap_bonus);
+        update_cap_history(capture_table[piece][to][chessboard.get_piece(to)], bonus);
     }
 
     for (const auto &capture: captures) {
-        int malus = -cap_bonus;
         auto cap_to = capture.get_to();
-        update_cap_history(capture_table[chessboard.get_piece(capture.get_from())][cap_to][chessboard.get_piece(cap_to)], malus);
+        update_cap_history(capture_table[chessboard.get_piece(capture.get_from())][cap_to][chessboard.get_piece(cap_to)], penalty);
     }
 }
 


### PR DESCRIPTION
Elo   | 1.64 +- 2.22 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [-3.00, 0.00]
Games | N: 25136 W: 5966 L: 5847 D: 13323
Penta | [76, 3015, 6248, 3172, 57]

Bench: 4132114