### PR TITLE
Major-Minor correction history

### DIFF
--- a/chess_board/board.hpp
+++ b/chess_board/board.hpp
@@ -35,6 +35,8 @@ struct board_info {
     chess_move move = {};
     zobrist hash_key = {};
     zobrist pawn_key = {};
+    zobrist minor_key = {};
+    zobrist major_key = {};
     std::array<zobrist, 2> nonpawn_key = {};
     std::uint64_t threats = {};
     std::uint64_t checkers = {};
@@ -69,6 +71,8 @@ public:
         side = Color::White;
         state->hash_key = zobrist();
         state->pawn_key = zobrist();
+        state->major_key = zobrist();
+        state->minor_key = zobrist();
         state->nonpawn_key[White] = state->nonpawn_key[Black] = zobrist();
 
         std::string board_str, side_str, castling_str, enpassant_str; //, fifty_move_clock, full_move_number
@@ -299,6 +303,8 @@ public:
         state->hash_key.update_side_hash();
         state->hash_key.update_enpassant_hash(old_info->enpassant);
         state->pawn_key = old_info->pawn_key;
+        state->minor_key = old_info->minor_key;
+        state->major_key = old_info->major_key;
         state->nonpawn_key = old_info->nonpawn_key;
         state->enpassant = Square::Null_Square;
         state->fifty_move_clock++;
@@ -323,6 +329,14 @@ public:
 
     [[nodiscard]] std::uint64_t get_pawn_key() const {
         return state->pawn_key.get_key();
+    }
+
+    [[nodiscard]] std::uint64_t get_minor_key() const {
+        return state->minor_key.get_key();
+    }
+
+    [[nodiscard]] std::uint64_t get_major_key() const {
+        return state->major_key.get_key();
     }
 
     [[nodiscard]] std::pair<std::uint64_t, std::uint64_t> get_nonpawn_key() const {
@@ -397,6 +411,8 @@ public:
         state->hash_key.update_enpassant_hash(old_state->enpassant);
         state->hash_key.update_side_hash();
         state->pawn_key = old_state->pawn_key;
+        state->major_key = old_state->major_key;
+        state->minor_key = old_state->minor_key;
         state->nonpawn_key = old_state->nonpawn_key;
         state->enpassant = Null_Square;
         state->castling_rights = old_state->castling_rights;
@@ -413,6 +429,14 @@ public:
             state->pawn_key.update_psqt_hash(color, piece, square);
         } else {
             state->nonpawn_key[color].update_psqt_hash(color, piece, square);
+            if (piece == Queen || piece == Rook) {
+                state->major_key.update_psqt_hash(color, piece, square);
+            } else if (piece == Knight || piece == Bishop) {
+                state->minor_key.update_psqt_hash(color, piece, square);
+            } else {
+                state->minor_key.update_psqt_hash(color, piece, square);
+                state->major_key.update_psqt_hash(color, piece, square);
+            }
         }
     }
 

--- a/cli/uci.hpp
+++ b/cli/uci.hpp
@@ -139,6 +139,8 @@ void uci_process(board& b, const std::string& line) {
         material_correction_table = {};
         material_history_table = {};
         threat_correction_table = {};
+        minor_correction_table = {};
+        major_correction_table = {};
         tt.clear();
     } else if (command == "setoption") {
         std::string token;
@@ -164,6 +166,8 @@ void uci_process(board& b, const std::string& line) {
         material_correction_table = {};
         material_history_table = {};
         threat_correction_table = {};
+        minor_correction_table = {};
+        major_correction_table = {};
         tt.clear();
         bench(13);
     } else if (command == "perft") {

--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -24,9 +24,11 @@ std::int16_t correct_eval(const board & chessboard, int raw_eval) {
     const int entry = correction_table[color][chessboard.get_pawn_key() % 16384];
     const std::uint64_t threat_key = murmur_hash_3(chessboard.get_threats() & chessboard.get_side_occupancy<color>());
     const int threat_entry = threat_correction_table[color][threat_key % 32768];
+    const int major_entry = major_correction_table[color][chessboard.get_major_key() % 16384];
+    const int minor_entry = minor_correction_table[color][chessboard.get_minor_key() % 16384];
     auto [wkey, bkey] = chessboard.get_nonpawn_key();
     const int nonpawn_entry = nonpawn_correction_table[color][White][wkey % 16384] + nonpawn_correction_table[color][Black][bkey % 16384];
-    return raw_eval + (entry * 2 + threat_entry + nonpawn_entry) / (256 * 3);
+    return raw_eval + (entry * 2 + threat_entry + nonpawn_entry + major_entry + minor_entry) / (256 * 3);
 }
 
 template <Color color>

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -49,9 +49,11 @@ std::int16_t correct_eval(const board & chessboard, int material_key, int threat
     const int entry = correction_table[color][chessboard.get_pawn_key() % 16384];
     const int material_entry = material_correction_table[color][material_key];
     const int threat_entry = threat_correction_table[color][threat_key];
+    const int major_entry = major_correction_table[color][chessboard.get_major_key() % 16384];
+    const int minor_entry = minor_correction_table[color][chessboard.get_minor_key() % 16384];
     auto [wkey, bkey] = chessboard.get_nonpawn_key();
     const int nonpawn_entry = nonpawn_correction_table[color][White][wkey % 16384] + nonpawn_correction_table[color][Black][bkey % 16384];
-    return raw_eval + (entry * 2 + material_entry + threat_entry + nonpawn_entry) / (256 * 3);
+    return raw_eval + (entry * 2 + material_entry + threat_entry + nonpawn_entry + major_entry + minor_entry) / (256 * 3);
 }
 
 template <Color color, NodeType node_type>
@@ -395,6 +397,14 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
             int & black_nonpawn_entry = nonpawn_correction_table[color][Black][bkey % 16384];
             black_nonpawn_entry = (black_nonpawn_entry * (256 - weight) + diff * weight) / 256;
             black_nonpawn_entry = std::clamp(black_nonpawn_entry, -8'192, 8'192);
+
+            int & major_entry = major_correction_table[color][chessboard.get_major_key() % 16384];
+            major_entry = (major_entry * (256 - weight) + diff * weight) / 256;
+            major_entry = std::clamp(major_entry, -8'192, 8'192);
+
+            int & minor_entry = minor_correction_table[color][chessboard.get_minor_key() % 16384];
+            minor_entry = (minor_entry * (256 - weight) + diff * weight) / 256;
+            minor_entry = std::clamp(minor_entry, -8'192, 8'192);
         }
 
         if (!would_tt_prune) {

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -13,6 +13,8 @@ std::array<std::array<std::array<std::array<int, 64>, 6>, 64>, 6> continuation_t
 std::array<std::array<std::array<int, 7>, 64>, 6> capture_table = {};
 std::array<std::array<int, 16384>, 2> correction_table = {};
 std::array<std::array<std::array<int, 16384>, 2>, 2> nonpawn_correction_table = {};
+std::array<std::array<int, 16384>, 2> minor_correction_table = {};
+std::array<std::array<int, 16384>, 2> major_correction_table = {};
 std::array<std::array<int, 32768>, 2> material_correction_table = {};
 std::array<std::array<int, 32768>, 2> threat_correction_table = {};
 


### PR DESCRIPTION
Idea from [Sirius](https://github.com/mcthouacbb/Sirius). Correct static evaluation based on minor and major piece structures. 

Elo   | 1.91 +- 1.51 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.96 (-2.25, 2.89) [0.00, 3.00]
Games | N: 54282 W: 13075 L: 12776 D: 28431
Penta | [169, 6425, 13684, 6664, 199]

Bench: 3924360