### PR TITLE
Corrhist weights

### DIFF
--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -19,16 +19,15 @@ auto murmur_hash_3(std::uint64_t key) -> std::uint64_t {
 };
 
 template <Color color>
-std::int16_t correct_eval(const board & chessboard, int raw_eval) {
+std::int16_t correct_eval(const board & chessboard, int threat_key, int raw_eval) {
     if (std::abs(raw_eval) > 8'000) return raw_eval;
     const int entry = correction_table[color][chessboard.get_pawn_key() % 16384];
-    const std::uint64_t threat_key = murmur_hash_3(chessboard.get_threats() & chessboard.get_side_occupancy<color>());
-    const int threat_entry = threat_correction_table[color][threat_key % 32768];
+    const int threat_entry = threat_correction_table[color][threat_key];
     const int major_entry = major_correction_table[color][chessboard.get_major_key() % 16384];
     const int minor_entry = minor_correction_table[color][chessboard.get_minor_key() % 16384];
     auto [wkey, bkey] = chessboard.get_nonpawn_key();
     const int nonpawn_entry = nonpawn_correction_table[color][White][wkey % 16384] + nonpawn_correction_table[color][Black][bkey % 16384];
-    return raw_eval + (entry * 195 + threat_entry * 102 + nonpawn_entry * 117 + major_entry * 92 + minor_entry * 137) / (256 * 300);
+    return raw_eval + (entry * 195 + threat_entry * 103 + nonpawn_entry * 118 + major_entry * 93 + minor_entry * 136) / (256 * 300);
 }
 
 template <Color color>
@@ -67,8 +66,9 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
             return tt_eval;
         }
     } else {
+        const std::uint64_t threat_key = murmur_hash_3(chessboard.get_threats() & chessboard.get_side_occupancy<color>());
         static_eval = eval = in_check ? -INF : evaluate<color>(chessboard);
-        eval = correct_eval<color>(chessboard, static_eval);
+        eval = correct_eval<color>(chessboard, threat_key % 32768, static_eval);
     }
 
     if (eval >= beta) {

--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -27,7 +27,7 @@ std::int16_t correct_eval(const board & chessboard, int threat_key, int raw_eval
     const int minor_entry = minor_correction_table[color][chessboard.get_minor_key() % 16384];
     auto [wkey, bkey] = chessboard.get_nonpawn_key();
     const int nonpawn_entry = nonpawn_correction_table[color][White][wkey % 16384] + nonpawn_correction_table[color][Black][bkey % 16384];
-    return raw_eval + (entry * 195 + threat_entry * 103 + nonpawn_entry * 118 + major_entry * 93 + minor_entry * 136) / (256 * 300);
+    return raw_eval + (entry * 195 + threat_entry * 102 + nonpawn_entry * 117 + major_entry * 92 + minor_entry * 137) / (256 * 300);
 }
 
 template <Color color>

--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -28,7 +28,7 @@ std::int16_t correct_eval(const board & chessboard, int raw_eval) {
     const int minor_entry = minor_correction_table[color][chessboard.get_minor_key() % 16384];
     auto [wkey, bkey] = chessboard.get_nonpawn_key();
     const int nonpawn_entry = nonpawn_correction_table[color][White][wkey % 16384] + nonpawn_correction_table[color][Black][bkey % 16384];
-    return raw_eval + (entry * 2 + threat_entry + nonpawn_entry + major_entry + minor_entry) / (256 * 3);
+    return raw_eval + (entry * 195 + threat_entry * 102 + nonpawn_entry * 117 + major_entry * 92 + minor_entry * 137) / (256 * 300);
 }
 
 template <Color color>

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -52,7 +52,7 @@ std::int16_t correct_eval(const board & chessboard, int material_key, int threat
     const int minor_entry = minor_correction_table[color][chessboard.get_minor_key() % 16384];
     auto [wkey, bkey] = chessboard.get_nonpawn_key();
     const int nonpawn_entry = nonpawn_correction_table[color][White][wkey % 16384] + nonpawn_correction_table[color][Black][bkey % 16384];
-    return raw_eval + (entry * 2 + threat_entry + nonpawn_entry + major_entry + minor_entry) / (256 * 3);
+    return raw_eval + (entry * 195 + threat_entry * 102 + nonpawn_entry * 117 + major_entry * 92 + minor_entry * 137) / (256 * 300);
 }
 
 template <Color color, NodeType node_type>

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -43,18 +43,6 @@ constexpr int asp_window_mul = 15;
 constexpr int asp_window_max = 666;
 constexpr int asp_depth = 8;
 
-template <Color color>
-std::int16_t correct_eval(const board & chessboard, int material_key, int threat_key, int raw_eval) {
-    if (std::abs(raw_eval) > 8'000) return raw_eval;
-    const int entry = correction_table[color][chessboard.get_pawn_key() % 16384];
-    const int threat_entry = threat_correction_table[color][threat_key];
-    const int major_entry = major_correction_table[color][chessboard.get_major_key() % 16384];
-    const int minor_entry = minor_correction_table[color][chessboard.get_minor_key() % 16384];
-    auto [wkey, bkey] = chessboard.get_nonpawn_key();
-    const int nonpawn_entry = nonpawn_correction_table[color][White][wkey % 16384] + nonpawn_correction_table[color][Black][bkey % 16384];
-    return raw_eval + (entry * 195 + threat_entry * 102 + nonpawn_entry * 117 + major_entry * 92 + minor_entry * 137) / (256 * 300);
-}
-
 template <Color color, NodeType node_type>
 std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha, std::int16_t beta, std::int8_t depth, bool cutnode) {
     constexpr Color enemy_color = color == White ? Black : White;
@@ -102,7 +90,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
         tt_move = tt_entry.tt_move;
         std::int16_t tt_eval = tt_entry.score;
         raw_eval = tt_entry.static_eval;
-        eval = static_eval = correct_eval<color>(chessboard, material_key % 32768, threat_key % 32768, raw_eval);
+        eval = static_eval = correct_eval<color>(chessboard, threat_key % 32768, raw_eval);
         tt_pv = tt_pv || tt_entry.tt_pv;
 
         if constexpr (!is_root) {
@@ -129,7 +117,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
         }
     } else {
         raw_eval = in_check ? -INF : evaluate<color>(chessboard);
-        eval = static_eval = correct_eval<color>(chessboard, material_key % 32768, threat_key % 32768, raw_eval);
+        eval = static_eval = correct_eval<color>(chessboard, threat_key % 32768, raw_eval);
         if (data.singular_move == 0 && depth >= iir_depth) {
             depth--;
         }


### PR DESCRIPTION
Elo   | 4.07 +- 2.57 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 18034 W: 4359 L: 4148 D: 9527
Penta | [34, 2064, 4627, 2241, 51]

Bench: 3835511