### PR TITLE
Concorrde - Continuation correction history

### DIFF
--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -46,7 +46,7 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
         }
     } else {
         static_eval = eval = in_check ? -INF : evaluate<color>(chessboard);
-        eval = history->correct_eval<color>(chessboard, static_eval);
+        eval = history->correct_eval<color>(chessboard, data,static_eval);
     }
 
     if (eval >= beta) {

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -89,7 +89,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
         tt_move = tt_entry.tt_move;
         std::int16_t tt_eval = tt_entry.score;
         raw_eval = tt_entry.static_eval;
-        eval = static_eval = history->correct_eval<color>(chessboard, raw_eval);
+        eval = static_eval = history->correct_eval<color>(chessboard, data, raw_eval);
         tt_pv = tt_pv || tt_entry.tt_pv;
 
         if constexpr (!is_root) {
@@ -116,7 +116,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
         }
     } else {
         raw_eval = in_check ? -INF : evaluate<color>(chessboard);
-        eval = static_eval = history->correct_eval<color>(chessboard, raw_eval);
+        eval = static_eval = history->correct_eval<color>(chessboard, data, raw_eval);
         if (data.singular_move == 0 && depth >= iir_depth) {
             depth--;
         }
@@ -360,7 +360,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
         if (!(in_check || !(best_move.get_value() == 0 || chessboard.is_quiet(best_move))
               || (flag == Bound::LOWER && best_score <= static_eval) || (flag == Bound::UPPER && best_score >= static_eval))
         ) {
-            history->update_correction_history<color>(chessboard, best_score, raw_eval, depth);
+            history->update_correction_history<color>(chessboard, data, best_score, raw_eval, depth);
         }
 
         if (!would_tt_prune) {

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -187,7 +187,7 @@ public:
             cont_entry = continuation_correction_table[prev2.piece_type][prev2.to][prev1.piece_type][prev1.to];
         }
 
-        return raw_eval + (entry * 192 + threat_entry * 88 + nonpawn_entry * 134 + major_entry * 84 + minor_entry * 146 + cont_entry * 100) / (256 * 300);
+        return raw_eval + (entry * 192 + threat_entry * 88 + nonpawn_entry * 134 + major_entry * 84 + minor_entry * 146 + cont_entry * 150) / (256 * 300);
     }
 
 


### PR DESCRIPTION
Correct static evaluation based on last two played moves

Elo   | 2.83 +- 2.04 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [0.00, 3.00]
Games | N: 29316 W: 7109 L: 6870 D: 15337
Penta | [77, 3410, 7461, 3617, 93]