### PR TITLE
New net

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Motor
 
-UCI chess engine written in C++ 20 with (768 x 3 -> 1536) x 2 -> 1 NNUE trained with [forge](https://github.com/martinnovaak/forge) and tested with custom [testing tool](https://github.com/martinnovaak/engineduel). 
+UCI chess engine written in C++ 20 with (768 x 8 -> 1024) x 2 -> 1 NNUE trained with [forge](https://github.com/martinnovaak/forge).
+A custom test [testing tool](https://github.com/martinnovaak/engineduel) was previously used to develop the engine. From June 2024, [Openbench](https://github.com/AndyGrant/OpenBench) is used instead for testing.
 
 Engine contains legal movegen with [kidergarten bitboards](https://github.com/martinnovaak/motor/blob/main/chess_board/slider_attacks/kindergarten.md).
 

--- a/evaluation/nnue.hpp
+++ b/evaluation/nnue.hpp
@@ -7,30 +7,31 @@
 
 #include <immintrin.h>
 
-constexpr unsigned int HIDDEN_SIZE = 1536;
+constexpr unsigned int HIDDEN_SIZE = 1024;
 constexpr int QA = 403;
 constexpr int QB = 81;
+constexpr int Cells = 8;
 
 constexpr std::array<int, 64> buckets = {
-        0, 0, 1, 1, 4, 4, 3, 3,
-        0, 0, 1, 1, 4, 4, 3, 3,
-        2, 2, 2, 2, 5, 5, 5, 5,
-        2, 2, 2, 2, 5, 5, 5, 5,
-        2, 2, 2, 2, 5, 5, 5, 5,
-        2, 2, 2, 2, 5, 5, 5, 5,
-        2, 2, 2, 2, 5, 5, 5, 5,
-        2, 2, 2, 2, 5, 5, 5, 5,
+        0, 1, 2, 3, 11, 10, 9, 8,
+        4, 4, 5, 5, 13, 13, 12, 12,
+        6, 6, 6, 6, 14, 14, 14, 14,
+        6, 6, 6, 6, 14, 14, 14, 14,
+        7, 7, 7, 7, 15, 15, 15, 15,
+        7, 7, 7, 7, 15, 15, 15, 15,
+        7, 7, 7, 7, 15, 15, 15, 15,
+        7, 7, 7, 7, 15, 15, 15, 15,
 };
 
 struct Weights {
-    std::array<std::array<std::array<std::array<std::array<std::int16_t, HIDDEN_SIZE>, 64>, 6>, 2>, 3> feature_weight;
+    std::array<std::array<std::array<std::array<std::array<std::int16_t, HIDDEN_SIZE>, 64>, 6>, 2>, Cells> feature_weight;
     std::array<std::int16_t, HIDDEN_SIZE> feature_bias;
     std::array<std::int16_t, HIDDEN_SIZE> output_weight_STM;
     std::array<std::int16_t, HIDDEN_SIZE> output_weight_NSTM;
     std::int16_t output_bias;
 };
 
-INCBIN(Weights, "nnue.bin");
+INCBIN(Weights, "8buckets.bin");
 const Weights& weights = *reinterpret_cast<const Weights*>(gWeightsData);
 
 enum class Operation {
@@ -91,7 +92,7 @@ public:
     template<Operation operation, Color perspective>
     void update_accumulator(const Piece piece, const Color color, const Square square, int king) {
         if constexpr (perspective == White) {
-            const auto& white_weights = weights.feature_weight[buckets[king] % 3][color][piece][get_square_index(square, king)];
+            const auto& white_weights = weights.feature_weight[buckets[king] % Cells][color][piece][get_square_index(square, king)];
             auto& white_accumulator = white_accumulator_stack[index];
 
             if constexpr (operation == Operation::Set) {
@@ -105,7 +106,7 @@ public:
                 }
             }
         } else {
-            const auto& black_weights = weights.feature_weight[buckets[king ^ 56] % 3][color ^ 1][piece][get_square_index(square, king) ^ 56];
+            const auto& black_weights = weights.feature_weight[buckets[king ^ 56] % Cells][color ^ 1][piece][get_square_index(square, king) ^ 56];
             auto& black_accumulator = black_accumulator_stack[index];
 
             if constexpr (operation == Operation::Set) {
@@ -123,8 +124,8 @@ public:
 
     template<Operation operation>
     void update_accumulator(const Piece piece, const Color color, const Square square, int wking, int bking) {
-        const auto& white_weights = weights.feature_weight[buckets[wking] % 3][color][piece][get_square_index(square, wking)];
-        const auto& black_weights = weights.feature_weight[buckets[bking ^ 56] % 3][color ^ 1][piece][get_square_index(square, bking) ^ 56];
+        const auto& white_weights = weights.feature_weight[buckets[wking] % Cells][color][piece][get_square_index(square, wking)];
+        const auto& black_weights = weights.feature_weight[buckets[bking ^ 56] % Cells][color ^ 1][piece][get_square_index(square, bking) ^ 56];
 
         auto& white_accumulator = white_accumulator_stack[index];
         auto& black_accumulator = black_accumulator_stack[index];

--- a/evaluation/nnue.hpp
+++ b/evaluation/nnue.hpp
@@ -31,7 +31,7 @@ struct Weights {
     std::int16_t output_bias;
 };
 
-INCBIN(Weights, "8buckets.bin");
+INCBIN(Weights, "nnue.bin");
 const Weights& weights = *reinterpret_cast<const Weights*>(gWeightsData);
 
 enum class Operation {


### PR DESCRIPTION
New net with more input buckets (3 -> 8) but with smaller hidden layer size (1536 -> 1024) trained with MPE 2.25 loss function.

 ```
Elo   | 3.72 +- 2.44 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 19786 W: 4755 L: 4543 D: 10488
Penta | [42, 2261, 5053, 2517, 20]
```