### PR TITLE
Change see threshold based on capture history score

### DIFF
--- a/search/move_ordering/move_ordering.hpp
+++ b/search/move_ordering/move_ordering.hpp
@@ -31,8 +31,9 @@ void score_moves(board & chessboard, move_list & movelist, search_data & data, c
         if (move == tt_move) {
             move_score = 214748364;
         } else if (!chessboard.is_quiet(move)) {
-            move_score = 10'000'000 * see<color>(chessboard, move) + mvv[chessboard.get_piece(to)];
-            move_score += history->get_capture_score(chessboard.get_piece(from), to, chessboard.get_piece(to));
+            int cap_score = history->get_capture_score(chessboard.get_piece(from), to, chessboard.get_piece(to));
+            move_score = 10'000'000 * see<color>(chessboard, move, -cap_score / 40) + mvv[chessboard.get_piece(to)];
+            move_score += cap_score;
         } else if (data.get_killer() == move){
             move_score = 1'000'002;
         } else {


### PR DESCRIPTION
Elo   | 6.38 +- 3.38 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.92 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10782 W: 2631 L: 2433 D: 5718
Penta | [29, 1211, 2717, 1401, 33]