### PR TITLE
Change conditions for correction history update

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -358,7 +358,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
     if (data.singular_move == 0) {
         if (!(in_check || !(best_move.get_value() == 0 || chessboard.is_quiet(best_move))
-              || (flag == Bound::LOWER && best_score <= static_eval) || (flag == Bound::UPPER && best_score >= static_eval))
+              || (flag == Bound::LOWER && best_score <= raw_eval) || (flag == Bound::UPPER && best_score >= raw_eval))
         ) {
             history->update_correction_history<color>(chessboard, data, best_score, raw_eval, depth);
         }


### PR DESCRIPTION
Change conditions for correction history update from corrected eval to raw evaluation

Elo   | 3.30 +- 2.27 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23920 W: 5863 L: 5636 D: 12421
Penta | [70, 2769, 6070, 2966, 85]

Bench: 4131841