### PR TITLE
Fix tt hits in singular search

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -84,7 +84,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
     bool would_tt_prune = false;
     bool tt_pv = is_pv;
 
-    if (data.singular_move == 0 && tt_entry.zobrist == tt.upper(zobrist_key)) {
+    if (tt_entry.zobrist == tt.upper(zobrist_key)) {
         best_move = tt_entry.tt_move;
         tt_move = tt_entry.tt_move;
         std::int16_t tt_eval = tt_entry.score;
@@ -102,7 +102,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
             }
         }
 
-        if (would_tt_prune) {
+        if (would_tt_prune && data.singular_move == 0) {
             if (is_pv) {
                 depth --;
             } else {


### PR DESCRIPTION
Don't evaluate nn in singular search and use score from transposition table instead

Elo   | 5.67 +- 4.18 (95%)
SPRT  | 6.0+0.06s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 7470 W: 1930 L: 1808 D: 3732
Penta | [29, 866, 1833, 968, 39]

Bench: 4854197