### PR TITLE
Add mate distance pruning

### DIFF
--- a/cli/uci.hpp
+++ b/cli/uci.hpp
@@ -125,7 +125,7 @@ void uci_process(board& b, const std::string& line) {
     } else if (command == "isready") {
         std::cout << "readyok" << std::endl;
     } else if (command == "uci") {
-        std::cout << "id name Motor 0.7.0 dev " << std::endl;
+        std::cout << "id name Motor 0.8.0 " << std::endl;
         std::cout << "id author Martin Novak " << std::endl;    
         std::cout << "option name Hash type spin default " << 32 << " min 1 max 1024" << std::endl;
         std::cout << "option name Threads type spin default 1 min 1 max 1" << std::endl;

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -61,6 +61,12 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
     bool in_check = false;
     if constexpr (!is_root) {
+        alpha = std::max(alpha, static_cast<std::int16_t>(-20'000 + data.get_ply()));
+        beta = std::min(beta, static_cast<std::int16_t>(20'000 - data.get_ply() - 1));
+        if (alpha > beta) {
+            return alpha;
+        }
+
         if (chessboard.is_draw()) {
             return 0;
         }
@@ -427,14 +433,21 @@ void iterative_deepening(board& chessboard, search_data& data, int max_depth) {
             break;
         }
 
-        std::cout << "info depth " << depth << " score cp " << score << " nodes " << data.nodes() << " nps " << data.nps() << " pv " << data.get_pv(depth) << std::endl;
+        std::string score_string = " score cp " + std::to_string(score);
+
+        if (std::abs(score) >= 19'000) {
+            if (score > 0) {
+                score_string = " mate " + std::to_string((20'000 - score + 1) / 2);
+            }
+            else {
+                score_string = " mate " + std::to_string(-(20'000 + score) / 2);
+            }
+        }
+
+        std::cout << "info depth " << depth << score_string << " nodes " << data.nodes() << " nps " << data.nps() << " pv " << data.get_pv(depth) << std::endl;
         data.reset_nodes();
 
         best_move = data.best_move;
-
-        if (depth > 20 && std::abs(score) > 19'900) {
-            break;
-        }
     }
     std::cout << "bestmove " << best_move << "\n";
 }

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -436,12 +436,7 @@ void iterative_deepening(board& chessboard, search_data& data, int max_depth) {
         std::string score_string = " score cp " + std::to_string(score);
 
         if (std::abs(score) >= 19'000) {
-            if (score > 0) {
-                score_string = " mate " + std::to_string((20'000 - score + 1) / 2);
-            }
-            else {
-                score_string = " mate " + std::to_string(-(20'000 + score) / 2);
-            }
+            score_string = " score mate " + std::to_string(score > 0 ? (20'000 - score + 1) / 2 : -(20'000 + score) / 2);
         }
 
         std::cout << "info depth " << depth << score_string << " nodes " << data.nodes() << " nps " << data.nps() << " pv " << data.get_pv(depth) << std::endl;


### PR DESCRIPTION
This patch adds mate distance pruning and removes a condition that often leads to unnecessarily slow checkmates.

Elo   | -0.38 +- 1.47 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 42370 W: 9578 L: 9624 D: 23168
Penta | [72, 3893, 13303, 3843, 74]

Bench: 4772074