### PR TITLE
History beta score tweak

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -349,7 +349,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
                     if (is_quiet) {
                         data.update_killer(chessmove);
                     }
-                    history->update<color, is_root>(data, chessboard, best_move, quiets, captures, depth, material_key % 512);
+                    history->update<color, is_root>(data, chessboard, best_move, quiets, captures, depth + (best_score > beta + 80), material_key % 512);
                     break;
                 }
             }


### PR DESCRIPTION
Elo   | 2.43 +- 1.84 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 36616 W: 9078 L: 8822 D: 18716
Penta | [123, 4304, 9186, 4584, 111]

Bench: 4463999