### PR TITLE
Give only bonus to killer moves

### DIFF
--- a/search/move_ordering/move_ordering.hpp
+++ b/search/move_ordering/move_ordering.hpp
@@ -36,6 +36,7 @@ void score_moves(board & chessboard, move_list & movelist, search_data & data, c
             move_score += cap_score;
         } else {
             move_score = history->get_quiet_score<color>(chessboard, data, from, to, chessboard.get_piece(from), material_key);
+            move_score += 32'000 * (data.get_killer() == move);
         }
         
         movelist[move_index] = move_score;

--- a/search/move_ordering/move_ordering.hpp
+++ b/search/move_ordering/move_ordering.hpp
@@ -34,8 +34,6 @@ void score_moves(board & chessboard, move_list & movelist, search_data & data, c
             int cap_score = history->get_capture_score(chessboard.get_piece(from), to, chessboard.get_piece(to));
             move_score = 10'000'000 * see<color>(chessboard, move, -cap_score / 40) + mvv[chessboard.get_piece(to)];
             move_score += cap_score;
-        } else if (data.get_killer() == move){
-            move_score = 1'000'002;
         } else {
             move_score = history->get_quiet_score<color>(chessboard, data, from, to, chessboard.get_piece(from), material_key);
         }


### PR DESCRIPTION
Elo   | 1.10 +- 2.10 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 28022 W: 6839 L: 6750 D: 14433
Penta | [88, 3352, 7040, 3445, 86]

Elo   | 1.26 +- 2.29 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.52 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 21230 W: 4958 L: 4881 D: 11391
Penta | [11, 2451, 5622, 2512, 19]