### PR TITLE
Use corrected evaluation for corrhist update

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -364,9 +364,9 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
     if (data.singular_move == 0) {
         if (!(in_check || !(best_move.get_value() == 0 || chessboard.is_quiet(best_move))
-              || (flag == Bound::LOWER && best_score <= raw_eval) || (flag == Bound::UPPER && best_score >= raw_eval))
+              || (flag == Bound::LOWER && best_score <= static_eval) || (flag == Bound::UPPER && best_score >= static_eval))
         ) {
-            history->update_correction_history<color>(chessboard, data, best_score, raw_eval, depth);
+            history->update_correction_history<color>(chessboard, data, best_score, static_eval, depth);
         }
 
         if (!would_tt_prune) {

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -181,7 +181,7 @@ public:
             cont_entry = continuation_correction_table[prev2.piece_type][prev2.to][prev1.piece_type][prev1.to];
         }
 
-        return raw_eval + (entry * 192 + threat_entry * 88 + nonpawn_entry * 134 + minor_entry * 146 + cont_entry * 150) / (256 * 300);
+        return raw_eval + (entry * 200 + threat_entry * 100 + nonpawn_entry * 145 + minor_entry * 145 + cont_entry * 160) / (256 * 300);
     }
 
 

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -181,7 +181,7 @@ public:
             cont_entry = continuation_correction_table[prev2.piece_type][prev2.to][prev1.piece_type][prev1.to];
         }
 
-        return raw_eval + (entry * 200 + threat_entry * 100 + nonpawn_entry * 145 + minor_entry * 145 + cont_entry * 160) / (256 * 300);
+        return raw_eval + (entry * 200 + threat_entry * 100 + nonpawn_entry * 200 + minor_entry * 150 + cont_entry * 180) / (256 * 300);
     }
 
 


### PR DESCRIPTION
Elo   | 0.89 +- 1.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
Games | N: 47616 W: 11935 L: 11813 D: 23868
Penta | [191, 5737, 11826, 5867, 187]

Elo   | 0.34 +- 1.66 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
Games | N: 40444 W: 9262 L: 9223 D: 21959
Penta | [33, 4666, 10800, 4675, 48]

Both tests would pass non-regression test 