### PR TITLE
Update correction history with average of raw_eval and static_eval

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -366,7 +366,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
         if (!(in_check || !(best_move.get_value() == 0 || chessboard.is_quiet(best_move))
               || (flag == Bound::LOWER && best_score <= static_eval) || (flag == Bound::UPPER && best_score >= static_eval))
         ) {
-            history->update_correction_history<color>(chessboard, data, best_score, static_eval, depth);
+            history->update_correction_history<color>(chessboard, data, best_score, (raw_eval + static_eval) / 2, depth);
         }
 
         if (!would_tt_prune) {

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -364,9 +364,9 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
     if (data.singular_move == 0) {
         if (!(in_check || !(best_move.get_value() == 0 || chessboard.is_quiet(best_move))
-              || (flag == Bound::LOWER && best_score <= raw_eval) || (flag == Bound::UPPER && best_score >= raw_eval))
+              || (flag == Bound::LOWER && best_score <= static_eval) || (flag == Bound::UPPER && best_score >= static_eval))
         ) {
-            history->update_correction_history<color>(chessboard, data, best_score, raw_eval, depth);
+            history->update_correction_history<color>(chessboard, data, best_score, static_eval, depth);
         }
 
         if (!would_tt_prune) {

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -181,7 +181,7 @@ public:
             cont_entry = continuation_correction_table[prev2.piece_type][prev2.to][prev1.piece_type][prev1.to];
         }
 
-        return raw_eval + (entry * 192 + threat_entry * 88 + nonpawn_entry * 134 + minor_entry * 146 + cont_entry * 150) / (256 * 300);
+        return raw_eval + (entry * 200 + threat_entry * 100 + nonpawn_entry * 145 + minor_entry * 145 + cont_entry * 160) / (256 * 300);
     }
 
 

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -181,7 +181,7 @@ public:
             cont_entry = continuation_correction_table[prev2.piece_type][prev2.to][prev1.piece_type][prev1.to];
         }
 
-        return raw_eval + (entry * 200 + threat_entry * 100 + nonpawn_entry * 145 + minor_entry * 145 + cont_entry * 160) / (256 * 300);
+        return raw_eval + (entry * 200 + threat_entry * 100 + nonpawn_entry * 200 + minor_entry * 150 + cont_entry * 180) / (256 * 300);
     }
 
 


### PR DESCRIPTION
The idea of @pkrisz99 - [Renegade](https://github.com/pkrisz99/Renegade) author. Update correction history with average of raw evaluation and corrected evaluation. 

Elo   | 7.91 +- 3.82 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 8394 W: 2158 L: 1967 D: 4269
Penta | [18, 931, 2122, 1094, 32]