### PR TITLE
Reintroduce major structure correction history

### DIFF
--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -200,7 +200,7 @@ public:
             }
         }
 
-        return raw_eval + (entry * 200 + threat_entry * 100 + nonpawn_entry * 200 + minor_entry * 150 + major_entry * 80 + cont_entry * 180 + cont_entry2 * 180) / (256 * 300);
+        return raw_eval + (entry * 200 + threat_entry * 100 + nonpawn_entry * 200 + minor_entry * 150 + major_entry * 120 + cont_entry * 180 + cont_entry2 * 180) / (256 * 300);
     }
 
 


### PR DESCRIPTION
Reintroduce correction of static evaluation based on major piece structure. Originally idea from [Sirius](https://github.com/mcthouacbb/Sirius) engine.

```
Elo   | 1.36 +- 1.09 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=32MB
LLR   | 2.91 (-2.25, 2.89) [0.00, 3.00]
Games | N: 106562 W: 26867 L: 26449 D: 53246
Penta | [404, 12762, 26590, 13062, 463]
```

