### PR TITLE
Change corrhist update condition to use average evaluation

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -363,10 +363,11 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
     }
 
     if (data.singular_move == 0) {
+        int avg_eval = (raw_eval + static_eval) / 2;
         if (!(in_check || !(best_move.get_value() == 0 || chessboard.is_quiet(best_move))
-              || (flag == Bound::LOWER && best_score <= static_eval) || (flag == Bound::UPPER && best_score >= static_eval))
+              || (flag == Bound::LOWER && best_score <= avg_eval) || (flag == Bound::UPPER && best_score >= avg_eval))
         ) {
-            history->update_correction_history<color>(chessboard, data, best_score, (raw_eval + static_eval) / 2, depth);
+            history->update_correction_history<color>(chessboard, data, best_score, avg_eval, depth);
         }
 
         if (!would_tt_prune) {


### PR DESCRIPTION
Would pass non regression test.

Elo   | 1.06 +- 1.42 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
Games | N: 60786 W: 15104 L: 14918 D: 30764
Penta | [186, 7229, 15382, 7405, 191]

Bench: 5209253