### PR TITLE
Remove material history

### DIFF
--- a/search/move_ordering/move_ordering.hpp
+++ b/search/move_ordering/move_ordering.hpp
@@ -22,7 +22,7 @@ constexpr int noisy_base = -409;
 constexpr int mvv[7] = { 500, 1000, 1000, 2000, 3000, 0, 1044 };
 
 template <Color color>
-void score_moves(board & chessboard, move_list & movelist, search_data & data, const chess_move & tt_move, int material_key) {
+void score_moves(board & chessboard, move_list & movelist, search_data & data, const chess_move & tt_move) {
     int move_index = 0;
     for (chess_move & move : movelist) {
         const Square from = move.get_from();
@@ -35,7 +35,7 @@ void score_moves(board & chessboard, move_list & movelist, search_data & data, c
             move_score = 10'000'000 * see<color>(chessboard, move, -cap_score / 40) + mvv[chessboard.get_piece(to)];
             move_score += cap_score;
         } else {
-            move_score = history->get_quiet_score<color>(chessboard, data, from, to, chessboard.get_piece(from), material_key);
+            move_score = history->get_quiet_score<color>(chessboard, data, from, to, chessboard.get_piece(from));
             move_score += 32'000 * (data.get_killer() == move);
         }
         

--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -60,7 +60,7 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
     move_list movelist;
     if (in_check) {
         generate_all_moves<color, false>(chessboard, movelist);
-        score_moves<color>(chessboard, movelist, data, tt_move, chessboard.get_material_key() % 512);
+        score_moves<color>(chessboard, movelist, data, tt_move);
         if (movelist.size() == 0) {
             return data.mate_value();
         }

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -78,7 +78,6 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
         return quiescence_search<color>(chessboard, data, alpha, beta);
     }
 
-    std::uint64_t material_key = chessboard.get_material_key();
     Bound flag = Bound::UPPER;
 
     std::uint64_t zobrist_key = chessboard.get_hash_key();
@@ -215,7 +214,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
     }
 
     std::int16_t best_score = -INF;
-    score_moves<color>(chessboard, movelist, data, best_move, material_key % 512);
+    score_moves<color>(chessboard, movelist, data, best_move);
 
     for (std::uint8_t moves_searched = 0; moves_searched < movelist.size(); moves_searched++) {
         chess_move& chessmove = movelist.get_next_move(moves_searched);
@@ -349,7 +348,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
                     if (is_quiet) {
                         data.update_killer(chessmove);
                     }
-                    history->update<color, is_root>(data, chessboard, best_move, quiets, captures, depth + (best_score > beta + 80), material_key % 512);
+                    history->update<color, is_root>(data, chessboard, best_move, quiets, captures, depth + (best_score > beta + 80));
                     break;
                 }
             }

--- a/search/tables/history_table.hpp
+++ b/search/tables/history_table.hpp
@@ -39,7 +39,7 @@ public:
     }
 
     template <Color color, bool is_root>
-    void update(search_data &data, board &chessboard, const chess_move &best_move, move_list &quiets, move_list &captures, int depth, int material_key) {
+    void update(search_data &data, board &chessboard, const chess_move &best_move, move_list &quiets, move_list &captures, int depth) {
         int bonus = history_bonus(depth);
         int penalty = -bonus;
 
@@ -95,7 +95,7 @@ public:
     }
 
     template <Color color>
-    int get_quiet_score(board &chessboard, const search_data &data, Square from, Square to, Piece piece, int material_key) const {
+    int get_quiet_score(board &chessboard, const search_data &data, Square from, Square to, Piece piece) const {
         std::uint64_t threats = chessboard.get_threats();
         bool threat_from = (threats & bb(from));
         bool threat_to = (threats & bb(to));


### PR DESCRIPTION
Remove material history and simplify out weights from other histories

Elo   | 1.08 +- 2.09 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 28392 W: 7189 L: 7101 D: 14102
Penta | [82, 3413, 7120, 3497, 84]

Bench: 5400836