### PR TITLE
Simplify lmr reductions to apply to all moves

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -296,11 +296,13 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
             // late move reduction
             if (depth >= lmr_depth && movelist.get_move_score(moves_searched) < 1'000'000) {
                 if (is_quiet) {
-                    reduction += !is_pv + !improving;
-                    reduction -= chessboard.in_check();
                     reduction -= movelist.get_move_score(moves_searched) / lmr_quiet_history;
                     reduction += cutnode * 2;
+                } else {
+                    reduction += cutnode;
                 }
+                reduction -= chessboard.in_check();
+                reduction += !is_pv + !improving;
                 reduction -= tt_pv;
 
                 reduction = std::clamp(reduction, 0, depth - 2);


### PR DESCRIPTION
Elo   | 0.77 +- 1.00 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
Games | N: 123898 W: 31258 L: 30985 D: 61655
Penta | [360, 14855, 31242, 15136, 356]

Bench: 4733847