### PR TITLE
Fix excluding moves in singular search

### DIFF
--- a/search/search_data.hpp
+++ b/search/search_data.hpp
@@ -115,7 +115,7 @@ public:
 
     history_move prev_moves[96];
 
-    std::uint32_t singular_move = {};
+    std::uint32_t singular_move[96] = {};
     int stack_eval = {};
     std::string best_move = {};
 private:


### PR DESCRIPTION
Elo   | 5.34 +- 4.72 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-5.00, 0.00]
Games | N: 5470 W: 1395 L: 1311 D: 2764
Penta | [10, 628, 1383, 696, 18]

Elo   | 2.51 +- 2.78 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.91 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 14274 W: 3520 L: 3417 D: 7337
Penta | [9, 1595, 3839, 1672, 22]

Bench: 4270440