### PR TITLE
Disable node prunings in singular search

### DIFF
--- a/cli/uci.hpp
+++ b/cli/uci.hpp
@@ -111,7 +111,7 @@ void uci_go(board& b, const std::string& command) {
         } else if (tokens[i] == "depth") {
             info.max_depth = std::stoi(tokens[i + 1]); 
         } else if (tokens[i] == "movetime") {
-            // info.movetime = std::stoi(tokens[i + 1]);  // NOT SUPPORTED RIGHT NOW
+            info.wtime = info.btime = 10 * std::max(10, std::stoi(tokens[i + 1]));
         } else if (tokens[i] == "infinite") {
             // info.infinite = true;                      
         } else if (tokens[i] == "nodes") {

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -134,7 +134,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
     data.singular_move[data.get_ply() + 1] = {};
 
     if constexpr (!is_root) {
-        if (!in_check && std::abs(beta) < 9'000) {
+        if (data.singular_move[data.get_ply()] == 0 && !in_check && std::abs(beta) < 9'000) {
             // razoring
             if (depth < razoring_depth && eval + razoring * depth <= alpha) {
                 std::int16_t razor_eval = quiescence_search<color>(chessboard, data, alpha, beta);


### PR DESCRIPTION
Elo   | 1.42 +- 2.24 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.89 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 22542 W: 5482 L: 5390 D: 11670
Penta | [13, 2644, 5872, 2722, 20]

Elo   | 0.77 +- 1.98 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
Games | N: 31598 W: 8011 L: 7941 D: 15646
Penta | [96, 3782, 7978, 3842, 101]

Bench: 4377390