### PR TITLE
Fail firm in rfp

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -145,7 +145,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
             // reverse futility pruning
             if (depth < rfp_depth && eval - (rfp - 48 * !is_pv) * (depth - improving) >= beta) {
-                return eval;
+                return (eval + beta) / 2;
             }
 
             // NULL MOVE PRUNING


### PR DESCRIPTION
Elo   | 3.36 +- 2.31 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 23350 W: 5893 L: 5667 D: 11790
Penta | [65, 2744, 5839, 2954, 73]

Bench: 4340505