### PR TITLE
skip all moves in futility pruning 

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -233,7 +233,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
 
                     int lmr_depth = std::max(0, depth - reduction - !improving + movelist.get_move_score(moves_searched) / 6000);
                     if (lmr_depth < fp_depth && static_eval + fp_base + fp_mul * lmr_depth <= alpha) {
-                        continue;
+                        break;
                     }
                 }
 


### PR DESCRIPTION
```
Elo   | 8.43 +- 3.95 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 7790 W: 1995 L: 1806 D: 3989
Penta | [17, 856, 1966, 1033, 23]
```

Bench: 4292184