### PR TITLE
Break in lmp

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -228,7 +228,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
             if (moves_searched && best_score > -9'000 && !in_check && movelist[moves_searched] < 20'000) {
                 if (is_quiet) {
                     if (quiets.size() > lmp_base + depth * depth / (2 - improving)) {
-                        continue;
+                        break;
                     }
 
                     int lmr_depth = std::max(0, depth - reduction - !improving + movelist.get_move_score(moves_searched) / 6000);


### PR DESCRIPTION
Elo   | 6.20 +- 3.32 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.89 (-2.25, 2.89) [0.00, 3.00]
Games | N: 10920 W: 2797 L: 2602 D: 5521
Penta | [26, 1217, 2783, 1404, 30]

Bench: 3909974