### PR TITLE
Fix qsearch correction

### DIFF
--- a/search/quiescence_search.hpp
+++ b/search/quiescence_search.hpp
@@ -38,11 +38,16 @@ std::int16_t quiescence_search(board & chessboard, search_data & data, std::int1
         std::int16_t tt_eval = tt_entry.score;
         tt_move = tt_entry.tt_move;
         static_eval = tt_entry.static_eval;
-        eval = tt_eval;
+        eval = history->correct_eval<color>(chessboard, data, static_eval);
         if ((tt_entry.bound == Bound::EXACT) ||
             (tt_entry.bound == Bound::LOWER && tt_eval >= beta) ||
             (tt_entry.bound == Bound::UPPER && tt_eval <= alpha)) {
             return tt_eval;
+        }
+
+        if (!((eval > tt_eval && tt_entry.bound == Bound::LOWER) || (eval < tt_eval && tt_entry.bound == Bound::UPPER)))
+        {
+            eval = tt_eval;
         }
     } else {
         static_eval = eval = in_check ? -INF : evaluate<color>(chessboard);


### PR DESCRIPTION
Elo   | 2.61 +- 2.88 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.93 (-2.25, 2.89) [-3.00, 1.00]
Games | N: 14386 W: 3583 L: 3475 D: 7328
Penta | [25, 1681, 3691, 1753, 43]

Bench: 4824822