### PR TITLE
Tweaking evaluation ration value for corrhist update

### DIFF
--- a/search/search.hpp
+++ b/search/search.hpp
@@ -359,7 +359,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
     }
 
     if (data.singular_move[data.get_ply()] == 0) {
-        int avg_eval = (raw_eval * 2 + static_eval) / 3;
+        int avg_eval = (raw_eval + static_eval * 2) / 3;
         if (!(in_check || !(best_move.get_value() == 0 || chessboard.is_quiet(best_move))
               || (flag == Bound::LOWER && best_score <= avg_eval) || (flag == Bound::UPPER && best_score >= avg_eval))
         ) {

--- a/search/search.hpp
+++ b/search/search.hpp
@@ -359,7 +359,7 @@ std::int16_t alpha_beta(board& chessboard, search_data& data, std::int16_t alpha
     }
 
     if (data.singular_move[data.get_ply()] == 0) {
-        int avg_eval = (raw_eval + static_eval) / 2;
+        int avg_eval = (raw_eval * 2 + static_eval) / 3;
         if (!(in_check || !(best_move.get_value() == 0 || chessboard.is_quiet(best_move))
               || (flag == Bound::LOWER && best_score <= avg_eval) || (flag == Bound::UPPER && best_score >= avg_eval))
         ) {


### PR DESCRIPTION
Elo   | 2.61 +- 1.93 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.90 (-2.25, 2.89) [0.00, 3.00]
Games | N: 32070 W: 7959 L: 7718 D: 16393
Penta | [82, 3700, 8220, 3961, 72]